### PR TITLE
Docker image uses stdio by default, add instructions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -68,10 +68,13 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v6
         with:
+          platforms: linux/amd64,linux/arm64
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,23 +4,19 @@ FROM python:3.13-slim-bookworm
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/
 
 # Install application
-ADD . /app
+ADD README.md LICENSE pyproject.toml uv.lock src /app/
 WORKDIR /app
-RUN uv sync --frozen
+ENV UV_FROZEN=true
+RUN uv sync
 
-# Set default environment variables
-ENV ZOTERO_LOCAL=false
-ENV ZOTERO_API_KEY=""
-ENV ZOTERO_LIBRARY_ID=""
-ENV ZOTERO_LIBRARY_TYPE="user"
-
-# Expose port 8000, standard for MCP
-EXPOSE 8000
+# Check basic functionality
+RUN uv run zotero-mcp --help
 
 LABEL org.opencontainers.image.title="zotero-mcp"
 LABEL org.opencontainers.image.description="Model Context Protocol Server for Zotero"
 LABEL org.opencontainers.image.url="https://github.com/zotero/zotero-mcp"
 LABEL org.opencontainers.image.source="https://github.com/zotero/zotero-mcp"
+LABEL org.opencontainers.image.license="MIT"
 
 # Command to run the server
-CMD ["uv", "run", "zotero-mcp", "--transport", "sse"]
+ENTRYPOINT ["uv", "run", "--quiet", "zotero-mcp"]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,33 @@ To use this with Claude Desktop and a direct python install with [`uvx`](https:/
 
 If you don't have `uvx` installed you can use `pipx run` instead, or clone this repository locally and use the instructions in [Development](#development) below.
 
+### Docker with Zotero Web API
+
+If you want to run this MCP server in a Docker container, you can use the following configuration, inserting your API key and library ID:
+
+```json
+{
+  "mcpServers": {
+    "zotero": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-e", "ZOTERO_API_KEY=PLACEHOLDER",
+        "-e", "ZOTERO_LIBRARY_ID=PLACEHOLDER",
+        "ghcr.io/kujenga/zotero-mcp:main"
+      ],
+    }
+  }
+}
+```
+
+It is also possible to use the docker-based installation to talk to the local Zotero API, but you'll need to modify the above command to ensure that there is network connectivity to the Zotero application's local API interface.
+
 ## Development
+
+Information on making changes and contributing to the project.
 
 1. Clone this repository
 1. Install dependencies with [uv](https://docs.astral.sh/uv/) by running: `uv sync`
@@ -69,8 +95,7 @@ Start the [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector) 
 npx @modelcontextprotocol/inspector uv run zotero-mcp
 ```
 
-To test the local repository against Claude Desktop, run `echo $PWD/.venv/bin/zotero-mcp` in your shell within this directory, then set the following within your Claude Desktop configuration:
-
+To test the local repository against Claude Desktop, run `echo $PWD/.venv/bin/zotero-mcp` in your shell within this directory, then set the following within your Claude Desktop configuration
 ```json
 {
   "mcpServers": {
@@ -90,6 +115,26 @@ To run the test suite:
 
 ```bash
 uv run pytest
+```
+
+### Docker Development
+
+Build the container image with this command:
+
+```sh
+docker build . -t zotero-mcp:local
+```
+
+To test the container with the MCP inspector, run the following command:
+
+```sh
+npx @modelcontextprotocol/inspector \
+    -e ZOTERO_API_KEY=$ZOTERO_API_KEY \
+    -e ZOTERO_LIBRARY_ID=$ZOTERO_LIBRARY_ID \
+    docker run --rm -i \
+        --env ZOTERO_API_KEY \
+        --env ZOTERO_LIBRARY_ID \
+        zotero-mcp:local
 ```
 
 ## Relevant Documentation


### PR DESCRIPTION
This allows the docker image to by default work over stdio in the same way that the uvx entrypoint approch does for simplicity.

Closes https://github.com/kujenga/zotero-mcp/issues/6