### PR TITLE
Upgrade dependencies to latest versions, README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To use this with Claude Desktop and a direct python install with [`uvx`](https:/
   "mcpServers": {
     "zotero": {
       "command": "uvx",
-      "args": ["--upgrade", "zotero-mcp"],
+      "args": ["zotero-mcp@latest"],
       "env": {
         "ZOTERO_LOCAL": "true",
         "ZOTERO_API_KEY": "",
@@ -60,7 +60,7 @@ To use this with Claude Desktop and a direct python install with [`uvx`](https:/
 }
 ```
 
-The `--upgrade` flag is optional and will pull the latest version when new ones are available. If you don't have `uvx` installed you can use `pipx run` instead, or clone this repository locally and use the instructions in [Development](#development) below.
+The `@latest` specifier is optional and will pull the latest version when new ones are available. If you don't have `uvx` installed you can use `pipx run` instead, or clone this repository locally and use the instructions in [Development](#development) below.
 
 ### Docker with Zotero Web API
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zotero-mcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "Model Context Protocol server for Zotero"
 authors = [{ name = "Aaron Taylor", email = "pypi@ataylor.io" }]
 readme = "README.md"

--- a/src/zotero_mcp/__init__.py
+++ b/src/zotero_mcp/__init__.py
@@ -134,7 +134,10 @@ def get_item_metadata(item_key: str) -> str:
         if not item:
             return f"No item found with key: {item_key}"
         return format_item(item)
-    except Exception as e:
+    # Broad catch is deliberate at an MCP tool boundary: an escaping exception
+    # aborts the tool call, whereas an error string lets the model see what
+    # went wrong and recover.
+    except Exception as e:  # noqa: BLE001
         return f"Error retrieving item metadata: {e!s}"
 
 
@@ -181,7 +184,8 @@ def get_item_fulltext(item_key: str) -> str:
         # Combine all sections
         return f"{header}{attachment_info}{full_text}"
 
-    except Exception as e:
+    # See get_item_metadata: errors are reported to the caller, not raised.
+    except Exception as e:  # noqa: BLE001
         return f"Error retrieving item full text: {e!s}"
 
 

--- a/src/zotero_mcp/__init__.py
+++ b/src/zotero_mcp/__init__.py
@@ -135,7 +135,7 @@ def get_item_metadata(item_key: str) -> str:
             return f"No item found with key: {item_key}"
         return format_item(item)
     except Exception as e:
-        return f"Error retrieving item metadata: {str(e)}"
+        return f"Error retrieving item metadata: {e!s}"
 
 
 @mcp.tool(
@@ -182,7 +182,7 @@ def get_item_fulltext(item_key: str) -> str:
         return f"{header}{attachment_info}{full_text}"
 
     except Exception as e:
-        return f"Error retrieving item full text: {str(e)}"
+        return f"Error retrieving item full text: {e!s}"
 
 
 @mcp.tool(

--- a/src/zotero_mcp/client.py
+++ b/src/zotero_mcp/client.py
@@ -1,9 +1,12 @@
+import logging
 import os
 from typing import Any
 
 from dotenv import load_dotenv
 from pydantic import BaseModel
 from pyzotero import zotero
+
+logger = logging.getLogger(__name__)
 
 # Load environment variables
 load_dotenv()
@@ -95,6 +98,13 @@ def get_attachment_details(
                 content_type=others[0][1],
             )
     except Exception:
-        pass
+        # Best-effort lookup: callers treat a missing attachment as a normal
+        # outcome, so log for diagnosis rather than surfacing the failure and
+        # losing the metadata we can still return.
+        logger.debug(
+            "Failed to resolve attachments for item %s",
+            data.get("key", ""),
+            exc_info=True,
+        )
 
     return None

--- a/src/zotero_mcp/client.py
+++ b/src/zotero_mcp/client.py
@@ -5,7 +5,6 @@ from dotenv import load_dotenv
 from pydantic import BaseModel
 from pyzotero import zotero
 
-
 # Load environment variables
 load_dotenv()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ import os
 from unittest.mock import patch
 
 import pytest
+
 from zotero_mcp.client import get_zotero_client
 
 
@@ -82,21 +83,23 @@ def test_get_zotero_client_local_mode(mock_env_vars_local):
 
 def test_get_zotero_client_local_mode_with_library_id():
     """Test client initialization in local mode with custom library ID"""
-    with patch.dict(
-        os.environ,
-        {
-            "ZOTERO_LIBRARY_ID": "custom_id",
-            "ZOTERO_LIBRARY_TYPE": "user",
-            "ZOTERO_API_KEY": "",
-            "ZOTERO_LOCAL": "true",
-        },
-        clear=True,
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "ZOTERO_LIBRARY_ID": "custom_id",
+                "ZOTERO_LIBRARY_TYPE": "user",
+                "ZOTERO_API_KEY": "",
+                "ZOTERO_LOCAL": "true",
+            },
+            clear=True,
+        ),
+        patch("zotero_mcp.client.zotero.Zotero") as mock_zotero,
     ):
-        with patch("zotero_mcp.client.zotero.Zotero") as mock_zotero:
-            get_zotero_client()
-            mock_zotero.assert_called_once_with(
-                library_id="custom_id",
-                library_type="user",
-                api_key=None,
-                local=True,
-            )
+        get_zotero_client()
+        mock_zotero.assert_called_once_with(
+            library_id="custom_id",
+            library_type="user",
+            api_key=None,
+            local=True,
+        )

--- a/tests/test_item_operations.py
+++ b/tests/test_item_operations.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from zotero_mcp import get_item_metadata, get_item_fulltext
+from zotero_mcp import get_item_fulltext, get_item_metadata
 
 
 def test_get_item_metadata(mock_zotero: Any, sample_item: dict[str, Any]) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -17,39 +17,20 @@ wheels = [
 
 [[package]]
 name = "annotated-types"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
-]
-
-[[package]]
-name = "anyio"
-version = "4.9.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.14'",
-]
-dependencies = [
-    { name = "idna", marker = "python_full_version < '3.14'" },
-    { name = "sniffio", marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916, upload-time = "2025-03-17T00:02:52.713Z" },
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
 ]
 
 [[package]]
 name = "anyio"
 version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-]
 dependencies = [
-    { name = "idna", marker = "python_full_version >= '3.14'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
 wheels = [
@@ -67,20 +48,20 @@ wheels = [
 
 [[package]]
 name = "bibtexparser"
-version = "1.4.3"
+version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyparsing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/8d/e296c7af03757debd8fc80df2898cbed4fb69fc61ed2c9b4a1d42e923a9e/bibtexparser-1.4.3.tar.gz", hash = "sha256:a9c7ded64bc137720e4df0b1b7f12734edc1361185f1c9097048ff7c35af2b8f", size = 55582, upload-time = "2024-12-19T20:41:57.754Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/1c/577d3ce406e88f370e80a6ebf76ae52a2866521e0b585e8ec612759894f1/bibtexparser-1.4.4.tar.gz", hash = "sha256:093b6c824f7a71d3a748867c4057b71f77c55b8dbc07efc993b781771520d8fb", size = 55594, upload-time = "2026-01-29T18:58:01.366Z" }
 
 [[package]]
 name = "certifi"
-version = "2025.1.31"
+version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577, upload-time = "2025-01-31T02:16:47.166Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393, upload-time = "2025-01-31T02:16:45.015Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
@@ -183,14 +164,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -260,14 +241,23 @@ wheels = [
 
 [[package]]
 name = "feedparser"
-version = "6.0.11"
+version = "6.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sgmllib3k" },
+    { name = "feedparser-sgmllib" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/aa/7af346ebeb42a76bf108027fe7f3328bb4e57a3a96e53e21fd9ef9dd6dd0/feedparser-6.0.11.tar.gz", hash = "sha256:c9d0407b64c6f2a065d0ebb292c2b35c01050cc0dc33757461aaabdc4c4184d5", size = 286197, upload-time = "2023-12-10T16:03:20.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/8a/a53da4a77352045d277978a2df322d5379369f9deb1707178899ff7e1121/feedparser-6.0.14.tar.gz", hash = "sha256:088679b0c4b543ee211a820dd544698c76a402122eae7473c04a43425f283d06", size = 286108, upload-time = "2026-07-30T14:07:40.491Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/d4/8c31aad9cc18f451c49f7f9cfb5799dadffc88177f7917bc90a66459b1d7/feedparser-6.0.11-py3-none-any.whl", hash = "sha256:0be7ee7b395572b19ebeb1d6aafb0028dee11169f1c934e0ed67d54992f4ad45", size = 81343, upload-time = "2023-12-10T16:03:19.484Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/61/f04912e63702e73fb2a378f9c0a1ad9eb17a334a11a6b3fe1daa593903c2/feedparser-6.0.14-py3-none-any.whl", hash = "sha256:e35e3f760151b0c3b22cac9684155cae186a233e16c49bcbc6c49e91e3131137", size = 80668, upload-time = "2026-07-30T14:07:39.175Z" },
+]
+
+[[package]]
+name = "feedparser-sgmllib"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/bf/ae3f20eceaa25fe720ec8f14662d35d39e73839fbbdad3c13bdee5397237/feedparser_sgmllib-2.0.1.tar.gz", hash = "sha256:32d46a92fe429d033c6793a45d4af28a150ff3e74f5bfdb598e26811ce4c2664", size = 22962, upload-time = "2026-07-30T19:18:10.723Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/ce/35ac725a2b0e6b3f4e03bb68167501cdecf3935132927c61342747f734a9/feedparser_sgmllib-2.0.1-py3-none-any.whl", hash = "sha256:113d6e0d7e1196200a13013044999aef75772d515f25a3e77c5e2047eb82c212", size = 10008, upload-time = "2026-07-30T19:18:09.237Z" },
 ]
 
 [[package]]
@@ -294,30 +284,11 @@ wheels = [
 
 [[package]]
 name = "httpcore2"
-version = "2.6.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.14'",
-]
-dependencies = [
-    { name = "h11", marker = "python_full_version < '3.14'" },
-    { name = "truststore", marker = "python_full_version < '3.14'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/53/db/2ad49878b36af4cff7527c1158b083ad6d9350462f1a35685cc3ebfa7c2b/httpcore2-2.6.0.tar.gz", hash = "sha256:95b692b582402ec49b3d84c2343556e4ac4c0962c8b3d39c48d485b9ecc240ab", size = 65592, upload-time = "2026-07-14T10:48:33.816Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/fa/08f483851a70ef10806e3b84240f2a8f923658035b794f7609795895d9ea/httpcore2-2.6.0-py3-none-any.whl", hash = "sha256:c237a45c7eef885cf032cb9b850d59fcf1fa7e00230307f08aab26486a6ed584", size = 81507, upload-time = "2026-07-14T10:48:31.504Z" },
-]
-
-[[package]]
-name = "httpcore2"
 version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-]
 dependencies = [
-    { name = "h11", marker = "python_full_version >= '3.14'" },
-    { name = "truststore", marker = "python_full_version >= '3.14'" },
+    { name = "h11" },
+    { name = "truststore" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
 wheels = [
@@ -329,8 +300,7 @@ name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "anyio" },
     { name = "certifi" },
     { name = "httpcore" },
     { name = "idna" },
@@ -342,35 +312,14 @@ wheels = [
 
 [[package]]
 name = "httpx2"
-version = "2.6.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.14'",
-]
-dependencies = [
-    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "httpcore2", version = "2.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "idna", marker = "python_full_version < '3.14'" },
-    { name = "truststore", marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/89/17/1e142bf3c76684232a092e1e4002be07fd3403b1c2dcb15d0012ea300c8f/httpx2-2.6.0.tar.gz", hash = "sha256:5d362fd59562cf2139a60c67bb016587a70b36156a517f176c7cbf1587d1ab22", size = 92736, upload-time = "2026-07-14T10:48:35.12Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/86/7d82f7c6aac32433eaf0c914b8bc870ae25759413b9d7d52ea6aa15f2546/httpx2-2.6.0-py3-none-any.whl", hash = "sha256:6cccc3665d6bceb3c1c4f1422ae7e53fda67a853f0135f09b25ce0d4dcac01e3", size = 88541, upload-time = "2026-07-14T10:48:32.681Z" },
-]
-
-[[package]]
-name = "httpx2"
 version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-]
 dependencies = [
-    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "httpcore2", version = "2.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "idna", marker = "python_full_version >= '3.14'" },
-    { name = "truststore", marker = "python_full_version >= '3.14'" },
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
@@ -388,11 +337,11 @@ wheels = [
 
 [[package]]
 name = "iniconfig"
-version = "2.1.0"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -424,14 +373,14 @@ wheels = [
 
 [[package]]
 name = "markdown-it-py"
-version = "3.0.0"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -439,10 +388,8 @@ name = "mcp"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "httpx2", version = "2.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "httpx2", version = "2.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "anyio" },
+    { name = "httpx2" },
     { name = "jsonschema" },
     { name = "mcp-types" },
     { name = "opentelemetry-api" },
@@ -503,20 +450,20 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "24.2"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950, upload-time = "2024-11-08T09:47:47.202Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451, upload-time = "2024-11-08T09:47:44.722Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
 name = "pluggy"
-version = "1.5.0"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -647,11 +594,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.1"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -670,35 +617,36 @@ crypto = [
 
 [[package]]
 name = "pyparsing"
-version = "3.2.3"
+version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bb/22/f1129e69d94ffff626bdb5c835506b3a5b4f3d070f17ea295e12c2c6f60f/pyparsing-3.2.3.tar.gz", hash = "sha256:b9c13f1ab8b3b542f72e28f634bad4de758ab3ce4546e4301970ad6fa77c38be", size = 1088608, upload-time = "2025-03-25T05:01:28.114Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/e7/df2285f3d08fee213f2d041540fa4fc9ca6c2d44cf36d3a035bf2a8d2bcc/pyparsing-3.2.3-py3-none-any.whl", hash = "sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf", size = 111120, upload-time = "2025-03-25T05:01:24.908Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
 name = "pytest"
-version = "8.3.5"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
 name = "python-dotenv"
-version = "1.1.0"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920, upload-time = "2025-03-25T10:14:56.835Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256, upload-time = "2025-03-25T10:14:55.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -708,15 +656,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
-]
-
-[[package]]
-name = "pytz"
-version = "2025.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
 ]
 
 [[package]]
@@ -743,17 +682,17 @@ wheels = [
 
 [[package]]
 name = "pyzotero"
-version = "1.6.11"
+version = "1.13.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bibtexparser" },
     { name = "feedparser" },
     { name = "httpx" },
-    { name = "pytz" },
+    { name = "whenever" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/20/33cfc165d48410a3d6c8fe7fb715ac51d4c646b41ee743a24f931c1ad96a/pyzotero-1.6.11.tar.gz", hash = "sha256:9773fa938f88ad3157d8125b9418e9bd8f2723395d0d1f034f741a43e0735774", size = 552337, upload-time = "2025-03-20T23:40:19.583Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/ad/df65faf44025486ab85c81bd2506935f0a0fe2b6b891088943b5f988860a/pyzotero-1.13.3.tar.gz", hash = "sha256:a9ff1c3f633f5365f23f7a6e7b98e05cec44e09bc249d91d21d5cf360f86871f", size = 555857, upload-time = "2026-07-28T08:32:03.636Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/75/0bced57e6ba014adeeaa504205c4a92d5211b6c5daa20c0a80b06de6d0f4/pyzotero-1.6.11-py3-none-any.whl", hash = "sha256:949cdff92fd688fe70f609c928f09ab25a7d2aa05f35c575725d5bd0f395d3b4", size = 26368, upload-time = "2025-03-20T23:40:17.536Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/23/00a66045646ef56b64a1797764ece5f309e35ec13c026293ca19b065a0da/pyzotero-1.13.3-py3-none-any.whl", hash = "sha256:323ba09a7a4341a70ed2289874b5d5a17d5501160d51041c242c549c81d4ffbe", size = 52040, upload-time = "2026-07-28T08:32:02.145Z" },
 ]
 
 [[package]]
@@ -772,15 +711,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "14.0.0"
+version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229, upload-time = "2025-03-30T14:15:12.283Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]
@@ -908,34 +847,28 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.11.2"
+version = "0.16.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/61/fb87430f040e4e577e784e325351186976516faef17d6fcd921fe28edfd7/ruff-0.11.2.tar.gz", hash = "sha256:ec47591497d5a1050175bdf4e1a4e6272cddff7da88a2ad595e1e326041d8d94", size = 3857511, upload-time = "2025-03-21T13:31:17.419Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/25/7113f6d5498888c5fb7db34081cba7d5971c4cb1bfb26819966eee68f003/ruff-0.16.1.tar.gz", hash = "sha256:fedad7c801dabd3fb9741d76aca39246e6ddd9ca446a015875207bf19f1e6bc7", size = 4877500, upload-time = "2026-07-30T19:37:01.379Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/99/102578506f0f5fa29fd7e0df0a273864f79af044757aef73d1cae0afe6ad/ruff-0.11.2-py3-none-linux_armv6l.whl", hash = "sha256:c69e20ea49e973f3afec2c06376eb56045709f0212615c1adb0eda35e8a4e477", size = 10113146, upload-time = "2025-03-21T13:30:26.68Z" },
-    { url = "https://files.pythonhosted.org/packages/74/ad/5cd4ba58ab602a579997a8494b96f10f316e874d7c435bcc1a92e6da1b12/ruff-0.11.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:2c5424cc1c4eb1d8ecabe6d4f1b70470b4f24a0c0171356290b1953ad8f0e272", size = 10867092, upload-time = "2025-03-21T13:30:37.949Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/3e/d3f13619e1d152c7b600a38c1a035e833e794c6625c9a6cea6f63dbf3af4/ruff-0.11.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ecf20854cc73f42171eedb66f006a43d0a21bfb98a2523a809931cda569552d9", size = 10224082, upload-time = "2025-03-21T13:30:39.962Z" },
-    { url = "https://files.pythonhosted.org/packages/90/06/f77b3d790d24a93f38e3806216f263974909888fd1e826717c3ec956bbcd/ruff-0.11.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c543bf65d5d27240321604cee0633a70c6c25c9a2f2492efa9f6d4b8e4199bb", size = 10394818, upload-time = "2025-03-21T13:30:42.551Z" },
-    { url = "https://files.pythonhosted.org/packages/99/7f/78aa431d3ddebfc2418cd95b786642557ba8b3cb578c075239da9ce97ff9/ruff-0.11.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20967168cc21195db5830b9224be0e964cc9c8ecf3b5a9e3ce19876e8d3a96e3", size = 9952251, upload-time = "2025-03-21T13:30:45.196Z" },
-    { url = "https://files.pythonhosted.org/packages/30/3e/f11186d1ddfaca438c3bbff73c6a2fdb5b60e6450cc466129c694b0ab7a2/ruff-0.11.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:955a9ce63483999d9f0b8f0b4a3ad669e53484232853054cc8b9d51ab4c5de74", size = 11563566, upload-time = "2025-03-21T13:30:47.516Z" },
-    { url = "https://files.pythonhosted.org/packages/22/6c/6ca91befbc0a6539ee133d9a9ce60b1a354db12c3c5d11cfdbf77140f851/ruff-0.11.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:86b3a27c38b8fce73bcd262b0de32e9a6801b76d52cdb3ae4c914515f0cef608", size = 12208721, upload-time = "2025-03-21T13:30:49.56Z" },
-    { url = "https://files.pythonhosted.org/packages/19/b0/24516a3b850d55b17c03fc399b681c6a549d06ce665915721dc5d6458a5c/ruff-0.11.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a3b66a03b248c9fcd9d64d445bafdf1589326bee6fc5c8e92d7562e58883e30f", size = 11662274, upload-time = "2025-03-21T13:30:52.055Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/65/76be06d28ecb7c6070280cef2bcb20c98fbf99ff60b1c57d2fb9b8771348/ruff-0.11.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0397c2672db015be5aa3d4dac54c69aa012429097ff219392c018e21f5085147", size = 13792284, upload-time = "2025-03-21T13:30:54.24Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/d2/4ceed7147e05852876f3b5f3fdc23f878ce2b7e0b90dd6e698bda3d20787/ruff-0.11.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:869bcf3f9abf6457fbe39b5a37333aa4eecc52a3b99c98827ccc371a8e5b6f1b", size = 11327861, upload-time = "2025-03-21T13:30:56.757Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/78/4935ecba13706fd60ebe0e3dc50371f2bdc3d9bc80e68adc32ff93914534/ruff-0.11.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2a2b50ca35457ba785cd8c93ebbe529467594087b527a08d487cf0ee7b3087e9", size = 10276560, upload-time = "2025-03-21T13:30:58.881Z" },
-    { url = "https://files.pythonhosted.org/packages/81/7f/1b2435c3f5245d410bb5dc80f13ec796454c21fbda12b77d7588d5cf4e29/ruff-0.11.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7c69c74bf53ddcfbc22e6eb2f31211df7f65054bfc1f72288fc71e5f82db3eab", size = 9945091, upload-time = "2025-03-21T13:31:01.45Z" },
-    { url = "https://files.pythonhosted.org/packages/39/c4/692284c07e6bf2b31d82bb8c32f8840f9d0627d92983edaac991a2b66c0a/ruff-0.11.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6e8fb75e14560f7cf53b15bbc55baf5ecbe373dd5f3aab96ff7aa7777edd7630", size = 10977133, upload-time = "2025-03-21T13:31:04.013Z" },
-    { url = "https://files.pythonhosted.org/packages/94/cf/8ab81cb7dd7a3b0a3960c2769825038f3adcd75faf46dd6376086df8b128/ruff-0.11.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:842a472d7b4d6f5924e9297aa38149e5dcb1e628773b70e6387ae2c97a63c58f", size = 11378514, upload-time = "2025-03-21T13:31:06.166Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/3a/a647fa4f316482dacf2fd68e8a386327a33d6eabd8eb2f9a0c3d291ec549/ruff-0.11.2-py3-none-win32.whl", hash = "sha256:aca01ccd0eb5eb7156b324cfaa088586f06a86d9e5314b0eb330cb48415097cc", size = 10319835, upload-time = "2025-03-21T13:31:10.7Z" },
-    { url = "https://files.pythonhosted.org/packages/86/54/3c12d3af58012a5e2cd7ebdbe9983f4834af3f8cbea0e8a8c74fa1e23b2b/ruff-0.11.2-py3-none-win_amd64.whl", hash = "sha256:3170150172a8f994136c0c66f494edf199a0bbea7a409f649e4bc8f4d7084080", size = 11373713, upload-time = "2025-03-21T13:31:13.148Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/d4/dd813703af8a1e2ac33bf3feb27e8a5ad514c9f219df80c64d69807e7f71/ruff-0.11.2-py3-none-win_arm64.whl", hash = "sha256:52933095158ff328f4c77af3d74f0379e34fd52f175144cefc1b192e7ccd32b4", size = 10441990, upload-time = "2025-03-21T13:31:15.206Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/694da69368e0973de65df2ddc73ab18d43c469d5963d9b150911de6bc513/ruff-0.16.1-py3-none-linux_armv6l.whl", hash = "sha256:58edb313b88f0c5460a26adf5f39a37a3be789494a15e3e411e35fa78b89f9a0", size = 10839126, upload-time = "2026-07-30T19:36:13.697Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f0/b626e5d5bd0dd9576263658ef12885e2288afd1029a48e26ffed65ec1ac1/ruff-0.16.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fde5a99e2f97479af66edd6622c6d5a2a7592c77cf4153d9e4428f5eeb55b60c", size = 11070253, upload-time = "2026-07-30T19:36:17.14Z" },
+    { url = "https://files.pythonhosted.org/packages/83/63/f40acfb6b35b88623e71684942b552c3edd96035f5d98f313815f7b277de/ruff-0.16.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e0d4c20532fca4f7fa609369161d968dd28f65d83dabbd61d8e9c7edbf7001f6", size = 10561425, upload-time = "2026-07-30T19:36:20.04Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/dd/14ec0e9c2b4d315547dd38765004b4863e354e1b52cb308272215d9f6f6d/ruff-0.16.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30affbcedf59ad5703d9c91f82266e02b47739f797e1a7b6e158e5526a6dae38", size = 10948879, upload-time = "2026-07-30T19:36:22.476Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e9/9d870cbae575030fdef595f04b4b97573c525b5497cce4f4498cf2f85446/ruff-0.16.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24e9c631573cbca9d20f1283f8f479b2afa4a8503504822bd71a293889f16743", size = 10643691, upload-time = "2026-07-30T19:36:24.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/09/12743d544e2173f53ecd27217c65f90d2bc0f8424a66a60339e56bbc0457/ruff-0.16.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b41bdd48fb420987a9b5212e4957c26ad4abce401fa9ea9d4d85843727945f4f", size = 11435354, upload-time = "2026-07-30T19:36:28.447Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/89/a1652b2daee52083c9554a6333b678a8b01d0400f976827bb87857f9449a/ruff-0.16.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b0d1e1393b7648079e13669de1c1f4fde06d4583e84d8fd5c1551e0a77a2aa75", size = 12259033, upload-time = "2026-07-30T19:36:31.326Z" },
+    { url = "https://files.pythonhosted.org/packages/16/96/ecdcb8c54ee7b123b487f807eb014e6e019155a0b81dfb669acd52f28ce3/ruff-0.16.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:07bf434b1c95f4e093be4532068ef4fcf00924eb2ade8796075980902d6fd54a", size = 11667981, upload-time = "2026-07-30T19:36:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/90/c52e12e0d862e9572f2a33aa227409143520abe53111e9a6babbac7b4af8/ruff-0.16.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39897739f112253ee4fdd2e8aa9a4f9ded99fb2be367d5f31dfa4ded6025584c", size = 11468183, upload-time = "2026-07-30T19:36:37.339Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6b/4ffb7ad1d83eb16cf8cbb3c8815d3f11c88460fd162d4b372a2059be1c2a/ruff-0.16.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:82ae3c0c0d74daf17b968a10b7b3bb3ef297ab7de0c1f749646b25e690ccb150", size = 11470071, upload-time = "2026-07-30T19:36:39.91Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/72/32ae7db4c0b5e32ab611787caa19d1546800676d79f7483b7100a3561bf4/ruff-0.16.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4d5f2ed10f8242d83fc08d521301089364e3375375705356f20c0e31606ef3ef", size = 10919503, upload-time = "2026-07-30T19:36:42.65Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/3d901ba6ad6fc38da39c3448fc6c59ac945679293a17c3ceb6d6c1cba13e/ruff-0.16.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a4665b309891f83f3e3c25447935f1213e9abbd4b5640af7a1f2def9f8d413c1", size = 10649861, upload-time = "2026-07-30T19:36:45.18Z" },
+    { url = "https://files.pythonhosted.org/packages/92/79/894ef1ced26552d5f8c9cf6d85b0687840e1128c55aeab7b9c2d54a0d880/ruff-0.16.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:26e9ca5c9bc3971f20d3cf18a957f52ffd6a5f6564ff15c4912a144dcac22494", size = 11148137, upload-time = "2026-07-30T19:36:47.936Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/69/3609a09fa1cb46cc28b762363e440a354204e5dff01bd0c8d7437874d6b9/ruff-0.16.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:67e1e1e3fa4f0c82f0e36d4cd61e661f6e7a6196cb1aa92fe0828fa7b8f257cd", size = 11559211, upload-time = "2026-07-30T19:36:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8a/fb22af2fd78a736e241fabf67e30ce1799a64244026377a49e133af90762/ruff-0.16.1-py3-none-win32.whl", hash = "sha256:d31765e131295b8445caf301e3e8a85b34d1b9b211b4109b7ba457888b051806", size = 10838258, upload-time = "2026-07-30T19:36:53.298Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/35/e57fd9fb5d423961df087a00b12d42c0a830288dc2f3b45ecca299158b4f/ruff-0.16.1-py3-none-win_amd64.whl", hash = "sha256:09b05e8b90c2cb06ad63464350e7a45e8e44a2dfe52072ebfba6666ca8d3f596", size = 11961111, upload-time = "2026-07-30T19:36:56.107Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/240ea004bf6dc4feb40e9832f2205a476a47dd5b8a3f8211a5fc5f95e20e/ruff-0.16.1-py3-none-win_arm64.whl", hash = "sha256:dbaadaac38c70239f056d306b7476f246b0bf000fa6b3876402acbf5b227eaf8", size = 11309414, upload-time = "2026-07-30T19:36:58.79Z" },
 ]
-
-[[package]]
-name = "sgmllib3k"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
 
 [[package]]
 name = "shellingham"
@@ -947,21 +880,11 @@ wheels = [
 ]
 
 [[package]]
-name = "sniffio"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
-]
-
-[[package]]
 name = "sse-starlette"
 version = "3.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "anyio" },
     { name = "starlette" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6c/10/a34c656829ffc1c4b22ef36d70d9ebb6b99c020e2aeb17cee5485099f028/sse_starlette-3.4.6.tar.gz", hash = "sha256:725f8a1bd6d26ae1b2c9610c0ef5065dfdd496f3988d28adcf8c4b49dc25c627", size = 32542, upload-time = "2026-07-20T14:16:32.201Z" }
@@ -974,8 +897,7 @@ name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
@@ -1029,16 +951,120 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/5b/879b2f932adfa7a053c360d50bc896c977fa6426109185f7c12ebdd0cb9d/tzlocal-5.4.4.tar.gz", hash = "sha256:8dbb8660838688a7b6ba4fed31d18dedf842afb4d47ca050d6d891c2c15f3be4", size = 31170, upload-time = "2026-06-29T08:03:40.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/a4/017a7a6cbe387d961a688ec31364ae60a5c4e22c96ae9921b79a947c855d/tzlocal-5.4.4-py3-none-any.whl", hash = "sha256:aae09f0126a8a86fa736be266eb4a471380d26a0de3bc14844e7821fee3e2a15", size = 18115, upload-time = "2026-06-29T08:03:38.666Z" },
+]
+
+[[package]]
 name = "uvicorn"
-version = "0.34.0"
+version = "0.52.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/4d/938bd85e5bf2edeec766267a5015ad969730bb91e31b44021dfe8b22df6c/uvicorn-0.34.0.tar.gz", hash = "sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9", size = 76568, upload-time = "2024-12-15T13:33:30.42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/c8/2d307868453a4bca6e64fa3581d122ae0748a0869c53f159339def179c7c/uvicorn-0.52.0.tar.gz", hash = "sha256:ca8876ad6c1983f394157c168b39d52f6dd56dabf5602fa0982751cffc2293ae", size = 97504, upload-time = "2026-07-29T08:45:34.065Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/14/33a3a1352cfa71812a3a21e8c9bfb83f60b0011f5e36f2b1399d51928209/uvicorn-0.34.0-py3-none-any.whl", hash = "sha256:023dc038422502fa28a09c7a30bf2b6991512da7dcdb8fd35fe57cfc154126f4", size = 62315, upload-time = "2024-12-15T13:33:27.467Z" },
+    { url = "https://files.pythonhosted.org/packages/39/e6/b5c0630ace9757232aec07112be8146b812787db52141ff9d50674aa7634/uvicorn-0.52.0-py3-none-any.whl", hash = "sha256:3d887809810b89ed33501bcf0a9aba469b06ecd608158efce04bd6b48d8c9b08", size = 79058, upload-time = "2026-07-29T08:45:32.492Z" },
+]
+
+[[package]]
+name = "whenever"
+version = "0.10.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "tzlocal", marker = "sys_platform != 'darwin' and sys_platform != 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/40/94856fe2439c4b8162d1a23b4cf3a48bb00bed0ed7b8d10add40988fa555/whenever-0.10.3.tar.gz", hash = "sha256:af8958c870bd178742f0089c3552d5702241cab1f4b6bdfd3b03111db4bc2150", size = 435946, upload-time = "2026-07-17T07:35:25.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/29/41eb6945633f7215b8c3d3081469d3365b6b9bb912c9e2c8568b1b15d08e/whenever-0.10.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:94303c122249ae40b70486fd99c384949f757898424613412c338ee794a56332", size = 602454, upload-time = "2026-07-17T07:33:28.602Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/95/a7cd3ae6596438f580cf8a1f196b8b8b44619265028a7b2e63712d4d5c8c/whenever-0.10.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b625440641c93c5574c06c720ce2d28cc20a6f07a5dfcf5cff4607ddd2c434a0", size = 585809, upload-time = "2026-07-17T07:33:30.446Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f5/a47fba0dee3d9ec3127b35d3f27d0c07b407c64c359f22f826b43c020ad5/whenever-0.10.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff5d6750307fded074c43b8a2ffab7edfe0a3137fd2a4e1b68888a02d38a0a75", size = 604431, upload-time = "2026-07-17T07:33:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/d6/f49e6ee57dc34ed6c624c4e582b924a3ec3e43fec094ed6d292560c8f667/whenever-0.10.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:70e3a315c098038c6d38fc46a4b5b62a1773425b1f7fff72c9690b07fd336218", size = 719312, upload-time = "2026-07-17T07:33:33.534Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/52/aff3be0affa8982eac4afc66c227cacd036fe0fe262db8374ff389a9f460/whenever-0.10.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:371e2e880efaa7dd8d4556467b67ac538d954782b7d2008dfd10609a706a184a", size = 640548, upload-time = "2026-07-17T07:33:34.954Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b9/11907246e776844d730fecd3ebc01ea0fb0824b1e715d910c1fbbbc69ea9/whenever-0.10.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:00a9bde975466aef2369ee1b78c727bdbcfc5a60443264c6124d96f60f0e07b3", size = 659315, upload-time = "2026-07-17T07:33:36.343Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/13/e36a4a7cd421b0165cb7ca65aecccf16ad4a2c59fba22dc59cd3a5a627c0/whenever-0.10.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24e3b7e0ab8aebd678ac777bac386e7fb67bd9b81063f678f4bd84da51247ec4", size = 619258, upload-time = "2026-07-17T07:33:37.765Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e7/656d0ff73f48e259dac41a436ca99e8ce073a50fd1a42021892cec1984db/whenever-0.10.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:19f2f994cb8c55c0abb5e29ba0a4b6aeb3bdce205fef726a82fb7e8ffe98c030", size = 730399, upload-time = "2026-07-17T07:33:39.194Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/fe/207c6c60259d4b59b3a3ae66e25312067141cc920f6c48770c3ca2dac21b/whenever-0.10.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7074967c9453d33e2a7fdb303ad99073bc224cb9e97cfbb9d6939e612c7cf78f", size = 780956, upload-time = "2026-07-17T07:33:40.859Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/80/c72a8d4df606f20b94c612fc09f3bb4b40bef15f982fc5d761f3ad33ba5b/whenever-0.10.3-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:95b93b83c2fc777c803724fb600032d14ca2cb1264c5eb9d8fd61fd935664282", size = 995674, upload-time = "2026-07-17T07:33:42.581Z" },
+    { url = "https://files.pythonhosted.org/packages/76/ae/ef99628f657083c7df3a7aaae47eadf28d63140b16d1ab7ed28a7af12070/whenever-0.10.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:bbf9a0c07b4d3c1b4f417d67932e8b82edd9f7ba4824581f90ecf15ef5a50558", size = 935419, upload-time = "2026-07-17T07:33:43.992Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c6/f2cbc40cf0a4eca202f7fcace67ccb226932b8ddb605300a54ff086e0fc8/whenever-0.10.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f15ceff2f39753d1a0d7d8e2695ae688fb171f0744d32a4ba05daef13e097686", size = 831909, upload-time = "2026-07-17T07:33:45.813Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/3a/bc0f5ae204494c47e46776e16f24592a6bbf700e98933b96967b228a46f7/whenever-0.10.3-cp311-cp311-win32.whl", hash = "sha256:f5e3e67ab029eb24c5b7eba668d900dbc48543abf9028b591a985bffdd907d8a", size = 614296, upload-time = "2026-07-17T07:33:47.242Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ca/40049f775b12906cd22912b92b66a374883e796c0ca653d0aa6b4f2b24b2/whenever-0.10.3-cp311-cp311-win_amd64.whl", hash = "sha256:b8add9d862fc190bd256804e23bfd4d5992064b4782950121fc0e6b54343ae04", size = 565310, upload-time = "2026-07-17T07:33:49.085Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/48/9e94222c81af15f7cd61efdb1675cb47f5270b9c1972a6082ea03df28d93/whenever-0.10.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9503c112bc9eaa3a25b630576db983bca363ea410acbd84255a2872c27a56f2e", size = 610824, upload-time = "2026-07-17T07:33:50.698Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/bc/d70b0d975597e75c379fe836fd6fb72c59241885a2bbfc6b3bb30e5e7801/whenever-0.10.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8df732c98620feb2e547c8569176d20075191d12126bc3d623c427cc17969918", size = 593837, upload-time = "2026-07-17T07:33:52.412Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b5/df5898f3f790552271ba044bff58b741ffed8ff475eaf245c8ade7901ed4/whenever-0.10.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd004e32913ea915193ab733481d20cd0fb837934de1a49948332b63345b4d64", size = 612472, upload-time = "2026-07-17T07:33:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/37/5e68ba7406217d5fb2d1fe2e118f3157525959de652da5b26a2889e97603/whenever-0.10.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8a2655f8debf3c96a7a2e2a687d2bd1175944aa4c6f596cb0fa5cad582f9865d", size = 728340, upload-time = "2026-07-17T07:33:55.602Z" },
+    { url = "https://files.pythonhosted.org/packages/87/9b/c8f3e85dfd9d7d64a04e24657dfa231a48b9b44f37257573c0b24ceabf6f/whenever-0.10.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8e8a157afc07ffd3f26886e2e2ba068a3d7382f79617a450aaf71c0242e9e6b5", size = 651303, upload-time = "2026-07-17T07:33:57.052Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d1/b4d8bf37bf8beb7b93f71c7dca9daa28c28f4c88069a00c8d47d9b4475f9/whenever-0.10.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2433707fe8638b9804dace2bac830f4a40f00d4157bdb7ee89aaa1ded8d308d9", size = 670566, upload-time = "2026-07-17T07:33:58.495Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/12/4cc8be0f2a7eed497853ad0f4510d4a4301b17ffb77807912fdbd746519a/whenever-0.10.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:444129d7da3c7af6bf2b8204d57935243a11c721e811678352e6183b3475685d", size = 628295, upload-time = "2026-07-17T07:33:59.938Z" },
+    { url = "https://files.pythonhosted.org/packages/da/25/4ef27dd88618c6a2fe6fb03f64534dcd3e6663531bae138d93d74b87896b/whenever-0.10.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f97c8bd35feacc17c3cd9b0b46ed39308a6e1c319c3fe8bc621dc658dce6043f", size = 738220, upload-time = "2026-07-17T07:34:01.453Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f0/e875dd1784f4a2e8abc80c88b93324a3ddcc05cb8c0e10a60547d0bd724f/whenever-0.10.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c872c444d50e4858fff004164c2b32ae760f30da577422d41146fd6e838aa6e8", size = 790022, upload-time = "2026-07-17T07:34:02.887Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c1/84fa4ce905fb9d3bc1508982bf605d6b820439dd49f2237b613696af8087/whenever-0.10.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a86a6f749dcb5e22c42456375d54eee36ac406b8bc97ab1e40dc7bb6aedb79d4", size = 1005579, upload-time = "2026-07-17T07:34:04.458Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/8c/63bcce272fa92802118134f523281bd4f139ac318a2df5c28796c6bbe343/whenever-0.10.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3504671935043750dd655716f5c8d2d3ec4e331a840c1d6f116bba73759b9e6a", size = 942597, upload-time = "2026-07-17T07:34:06.252Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/21/252b0800ee34fc3cd6d3e1429fa0d2e23f5c925e7df4517e59432a08d033/whenever-0.10.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8cd4985663cdcd1005700cfc8e1ab5ecd38ba6d43e9052784100e1311307cf2e", size = 841387, upload-time = "2026-07-17T07:34:08.057Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6c/94de1fd66e2dec6c63be92d84aa03789df860ba7765bc0b0a8117981969f/whenever-0.10.3-cp312-cp312-win32.whl", hash = "sha256:a25e3245fb2aad53f52f9fdb81dbee7aabd86a496e3e0b45c69a80d22518524e", size = 617772, upload-time = "2026-07-17T07:34:09.736Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b0/2fdc06490383f55e2627fec672256c4430f8a5a6c9cb37735f067258a8d1/whenever-0.10.3-cp312-cp312-win_amd64.whl", hash = "sha256:b61a35fd6bbd4f2bc16f831304194bab8891295b006abbfba859825b9cbaddb1", size = 573342, upload-time = "2026-07-17T07:34:11.193Z" },
+    { url = "https://files.pythonhosted.org/packages/52/6c/035f5b2c14e4eb4d820fbfcd0f66c6612b4a9e763b32556d237fd747c579/whenever-0.10.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:63f5d6de4690c69929d9f11ae53aa6907fdbe8a390ee22f001576b268b22d5bb", size = 610763, upload-time = "2026-07-17T07:34:12.687Z" },
+    { url = "https://files.pythonhosted.org/packages/54/e1/bd9a5e1ce72c0568ff3bfb662d32d41a6dbe2215a2c2a7fe2d4a0b8bf01f/whenever-0.10.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ffdca19003048aa5b93df35eda8fe7bf6c059b3788026b3276b09cb7a2838e6c", size = 593633, upload-time = "2026-07-17T07:34:14.16Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/61/3f8a500f3e74e7367f1205b32d21a7b7714d2d701ce755458fbbc835c4c5/whenever-0.10.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7eb90201b0a3681f38f58c82db12427476fcab85088a4292b119aab32fef5f6b", size = 612575, upload-time = "2026-07-17T07:34:15.577Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/66/b6e4ce1452dda7e860a523b2e046151625404c98157486362fe978ba0f90/whenever-0.10.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4aef14f67d4151272e9cc62700e1df0c8932da3ee74cbaf9a6d540d9796d4e3c", size = 727963, upload-time = "2026-07-17T07:34:16.995Z" },
+    { url = "https://files.pythonhosted.org/packages/70/00/8394bcae1ba8c9912280c2bbee90179f76d623a7b1da4b679bcce49dcede/whenever-0.10.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8a429e6431243d5317d7bb16f9a061d6e301efaf6498714180bde9a65c578ba", size = 651475, upload-time = "2026-07-17T07:34:18.671Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b7/b17069141fd30e42fe32dacdd9a550fe1adda4f09410a9fcdde67c473643/whenever-0.10.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f6e4d7a2fc2b80c65eb0f0310669f5cf79c6d8f745cc2df4fa1fb3e8f534cd22", size = 670690, upload-time = "2026-07-17T07:34:20.167Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/6b/13206e5287130d69c5dc2bd1c377197f2755e65a44e76a467dc026750828/whenever-0.10.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c33c65dc5489ca2a61a33769cc58badd3cdaf0b497884d627e7fe020fbe3c96e", size = 628283, upload-time = "2026-07-17T07:34:21.745Z" },
+    { url = "https://files.pythonhosted.org/packages/32/dd/30eeffe9091cfec929b286f220b27ddc779e11ff42411851c94d7f2c5fd9/whenever-0.10.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c81c5507586dad7fb1370575d16d6b5e8e470f5f80a0fdbbe8d3ec2a6be67d7c", size = 737863, upload-time = "2026-07-17T07:34:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/04/27/5f30db0f93aabb9681de979c988604f3754a159de25f3fa56459457501c1/whenever-0.10.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:11a003b768374f5bd29a7a486c1bca68241175dd6ef74c9007873d2d90ccf6e7", size = 790171, upload-time = "2026-07-17T07:34:25.057Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2c/37ed2019ddfb2ea9e0bc4875dc065dd6ed8f525fada317042d94458d644a/whenever-0.10.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:6b2a7b60723ff9100731b4ed60ed14dbe8c0128a58028caeec21c78d5fae74ed", size = 1005321, upload-time = "2026-07-17T07:34:26.669Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/01/97a13f69cc31e8d3b5c011667b600d0d1d2eb44791632e6b5ec1ce70ed8a/whenever-0.10.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2d3bcc8f66e0292d2fc1b22024c4ec92f01835c2b5a75e15d2633c8d640bb7cf", size = 942925, upload-time = "2026-07-17T07:34:28.137Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/ab/aa97eef13dc1cc4ef80535b4d3c6bcfe35a31df676866183becdd84e0474/whenever-0.10.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:214c6accd92a98de027c88c3246ab1a5398a8408ebea59c8299a3464080023e4", size = 841410, upload-time = "2026-07-17T07:34:29.726Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ca/f69cb9b8ed0593e5c405d676496b7e01c665d7839aa2ce51fdb53cc3a542/whenever-0.10.3-cp313-cp313-win32.whl", hash = "sha256:8488045413cbf4983d4b3e2bf56e49c5ae74cec9143a25bec172bda1ef1c4291", size = 618339, upload-time = "2026-07-17T07:34:31.257Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b6/2ab0264d2e53888ad329337acffdd76da221ccbbbf4f391a2ff3591af950/whenever-0.10.3-cp313-cp313-win_amd64.whl", hash = "sha256:0f7078c6119d5df8c292829bf7a0ac51e52346c8988c8bb7b7e852980c491f5b", size = 573430, upload-time = "2026-07-17T07:34:32.704Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/bd/eeb2921a39872eaae016cf81fe046183df936d0528a34a155551e8355ef8/whenever-0.10.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:09fc2cfc7352bb0b6e13e390803a010084d38fa633438f596c6959ef82fb9453", size = 613069, upload-time = "2026-07-17T07:34:34.59Z" },
+    { url = "https://files.pythonhosted.org/packages/04/34/f25c6ec3e96b6be8fd35b4a71ea93d64e91ed2e63498bdfd33a4ca5065bb/whenever-0.10.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f5a70afe144314e17e42344e1e6c57897d7df387469dca256d5cea5bd1d8d950", size = 596234, upload-time = "2026-07-17T07:34:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ef/feee6990d2ab70a442933c55392c1f6c4fcdaa9931f0ff431c6a57430dee/whenever-0.10.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27133d3197ec244730d6ea327f80e8f51bfa19e0c7d2f663f679ac03dd793283", size = 614173, upload-time = "2026-07-17T07:34:37.961Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3e/d91ecc0a2022043393cf14737cb0772aaf9e4b4601a13c9908ec32af907d/whenever-0.10.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d8fc72814ebb5458f66eb4cd60be1645d7922880f1af97301ea2695f1bec1bfe", size = 731043, upload-time = "2026-07-17T07:34:39.482Z" },
+    { url = "https://files.pythonhosted.org/packages/35/17/84995804c4ae42ad7b284186de4111f7833cf8bf7b353d6c620d4cc290ca/whenever-0.10.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:52ff7d3064cf4d918b9078cfdaf47d2c24e56f19179a57c42e42db8863930e14", size = 652259, upload-time = "2026-07-17T07:34:41.043Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7b/ed3a993140043d0f4e539131dce7efc0377212b075375f56e2d222b6cb13/whenever-0.10.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bf576747d4ceca14edc20e125766f44498cdffbbe6d7870ce3b8cec1d8284d76", size = 671286, upload-time = "2026-07-17T07:34:42.7Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/36/5baa820486e9b671523105a45b71f466690f3f72450c805c66b17b4c265e/whenever-0.10.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0278c260bd125dd83c3605ce4aeaef6e84356b73bb18df409d60afdc9d923052", size = 631067, upload-time = "2026-07-17T07:34:44.237Z" },
+    { url = "https://files.pythonhosted.org/packages/df/29/f714b73232177ef11c27a000a243d5a9e75ed2610d98da75f9e573bf0934/whenever-0.10.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:608ba733262f1bcef9cb5820acc5eb496048f3014e08ab0a6f84a0f9ec98d0a8", size = 739559, upload-time = "2026-07-17T07:34:45.977Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/aa/a17853efcfe1152b9327179d0beb8519d36a98c9405d99b3dbcedcc24d88/whenever-0.10.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:66b7bbdf17fca6b60946e8bb3f4ce87e2b0821ad220d0ed2cf6c98b1ca50d0fa", size = 792359, upload-time = "2026-07-17T07:34:47.599Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/61/cb7281660253d2450ce9638885e1ced8d243501be022421fe7ce1ff5eca7/whenever-0.10.3-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:4fd4fa5be94eae3bedb78677a8cc1ee2191a65c7895a03adf0e997c34ed22ae3", size = 1007547, upload-time = "2026-07-17T07:34:49.522Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/aa/f8ef6e423844bf0455ac078c2c3592edba4c40b1beac3c236f1197eeff16/whenever-0.10.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:7b4c9a1f1d709745db0a90cee319a7fb4990b41bce036959caf38d9c289fe5ce", size = 946200, upload-time = "2026-07-17T07:34:51.389Z" },
+    { url = "https://files.pythonhosted.org/packages/44/4f/9ee913152b5eaf6de437e500f7680649c8158541294a50b2fb45283970a6/whenever-0.10.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:210b09d6beaf79e3dcb644bc4a656fcda4ce678aa97607db73a6a8e1fabe146e", size = 844114, upload-time = "2026-07-17T07:34:53.394Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/da/4d4bd34a7336a1d19b79da56d106ff402d41d0e0e43dea2ffb3a476d1b76/whenever-0.10.3-cp314-cp314-win32.whl", hash = "sha256:9d1cb33a3ecdd59365de36d316daf8a0369cf69ed79a28aefdb027fe7e886028", size = 620418, upload-time = "2026-07-17T07:34:55.299Z" },
+    { url = "https://files.pythonhosted.org/packages/41/34/dc8cf6f3f6d02dcb71eba279f93ab1a68cb636699344a77ea65c98f4d03b/whenever-0.10.3-cp314-cp314-win_amd64.whl", hash = "sha256:8ebfac236f641b20363b86227c710a6d04e03a082b7438789874a2e96d54ee57", size = 575797, upload-time = "2026-07-17T07:34:56.932Z" },
+    { url = "https://files.pythonhosted.org/packages/34/81/b7e02c68a51d5a629b47dbf082006c1651c79a85fb659dc4006891048f1a/whenever-0.10.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:b27b8225b8a76b44c181d3af883387a079766d6c0e3ceddc54bfd0b53a20e7fd", size = 605161, upload-time = "2026-07-17T07:34:58.77Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f6/ef6c57426c9578962ea05ba0efe667b21c4ac42b516a50b8b3026b4b35f5/whenever-0.10.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:45530d5229dc80820eea7ec520f2290a326b3af05dbfdc9c2fedf09aa7a6710d", size = 587812, upload-time = "2026-07-17T07:35:00.384Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/53/12e1d7410e12715f6523aaf9599ce7c62a739dbd39cdd6a89ffeaf4253e4/whenever-0.10.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a86ac6faa2e29e76ce8c335b32b467d9617c0c99bb25e950e6a7f06dbaeea212", size = 604669, upload-time = "2026-07-17T07:35:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/79/6c/b1995aecba751bd56017dea6f3104135e253679b6ba1fdd96474b6f5b498/whenever-0.10.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e245a4bde91ced79a5f6f09a1ff4d2d5688f1f523cd81353d9a0a68d53e30385", size = 730777, upload-time = "2026-07-17T07:35:03.677Z" },
+    { url = "https://files.pythonhosted.org/packages/24/c4/4c9549c2c79702e902611f5361b77cbb5b8c58ab10a040101f18a4049fe9/whenever-0.10.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6978d74305e244a30eadab227624c439fdc242905e7069571477a2d5a052e4d6", size = 652316, upload-time = "2026-07-17T07:35:05.846Z" },
+    { url = "https://files.pythonhosted.org/packages/10/55/213c39c7bd4a46b989a7548000543f090954753a13d5b084319eb3b94643/whenever-0.10.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0cec3d19399b6986728c25a3465f6d176e8f93e6f2d7f53563eb605d8d01a82c", size = 670488, upload-time = "2026-07-17T07:35:07.683Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3e/e89cb3cb7d08a0344131a8179bf3474b8df944fe7bf443635574968385e9/whenever-0.10.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27ba23ff052904a66d5a2ba8361e728385bc6e3a44d43298d26784068402094c", size = 620313, upload-time = "2026-07-17T07:35:09.594Z" },
+    { url = "https://files.pythonhosted.org/packages/45/f9/8bedf9fdc4e214eed729e6bec2b2592883a061604b9568bbf537786f1e79/whenever-0.10.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:35ce45c760a700f3e39979929bcc60a30704886147a9271d25936de9271c2d67", size = 730015, upload-time = "2026-07-17T07:35:11.72Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ba/6f25da7fa960c4b193a862307451ce74ed1fadd127b2c58ecd8f26c86bf3/whenever-0.10.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7679c441528bd38f7b8ff4542209b54c563d8fb748f2263aafe6dda39b13acc5", size = 781854, upload-time = "2026-07-17T07:35:13.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/72/800855df931f910c10303b510f3c47a5ffad51512a47a8505b703d1a60d1/whenever-0.10.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:12b53025d7c28b7ff7f0d0c1d9cbecdc46ef93a67eecb162914fc968a6b25ef4", size = 1006236, upload-time = "2026-07-17T07:35:15.269Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/f42f62f6713ad005d4e3f67f75278f9c59c4da8608442346542944e4b802/whenever-0.10.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:274b894be0cf4d3167d3d55ad5521ed35c79dd531b7bf08b4d6aa76f88c2bda0", size = 936347, upload-time = "2026-07-17T07:35:17.251Z" },
+    { url = "https://files.pythonhosted.org/packages/39/39/400bd77ba48dbe35353bc7201e1fe6f9289117d702e0d9ca20d86f805c5d/whenever-0.10.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:64aac5a14d10cb02967b27775c8033a5bc8d70dbd613dbf8e5811417b5655aff", size = 833224, upload-time = "2026-07-17T07:35:19.054Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/84/4e2b32b3e5d20bc164da50d5b9d169f3d7b00d2bfd095ae01406623663d7/whenever-0.10.3-cp314-cp314t-win32.whl", hash = "sha256:b4589ce90fe5018c55b70460706119068d7a087bb860c6cbee2e9176578c829c", size = 613786, upload-time = "2026-07-17T07:35:20.689Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/21/d43cfdb655638f008e349a4ad62b5d45dde5322f45146262a0aba55ee130/whenever-0.10.3-cp314-cp314t-win_amd64.whl", hash = "sha256:2a761adc97ced36455c8b94d39cee43f45c009cd2870d246e518072fd3f2730b", size = 565695, upload-time = "2026-07-17T07:35:22.398Z" },
+    { url = "https://files.pythonhosted.org/packages/18/00/50e9b44b080813feb958b31e9e370a430444e8676d451a35f28bc638074c/whenever-0.10.3-py3-none-any.whl", hash = "sha256:d35778c88db6d0229c436014a4704180520315a1d5ed3b71ee6ba120cbfb9b3e", size = 121694, upload-time = "2026-07-17T07:35:24.291Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1069,7 +1069,7 @@ wheels = [
 
 [[package]]
 name = "zotero-mcp"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
Versions were out of date, and uvx no longer supports a `--upgrade` flag. This updates things accordingly.