### PR TITLE
feat: return complete item metadata, with citation keys and per-type sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,8 @@ This project is a python server that implements the [Model Context Protocol (MCP
 This MCP server provides the following tools:
 
 - `zotero_search_items`: Search for items in your Zotero library using a text query
-- `zotero_item_metadata`: Get the complete metadata for a specific Zotero item
+- `zotero_item_metadata`: Get the complete metadata for a specific Zotero item, covering every populated field grouped into publication details, identifiers, timestamps, and library information
 - `zotero_item_fulltext`: Get the full text of a specific Zotero item (i.e. PDF contents)
-
-`zotero_item_metadata` returns every populated field on the item, grouped into
-publication details, identifiers, timestamps, and library information. Fields
-from Zotero schema versions newer than this server are still rendered, so
-upgrading Zotero never silently drops metadata.
-
-Citation keys are included wherever they are available, both in search results
-and in item metadata. Zotero 8 and later expose `citationKey` as a native field
-on nearly every item type; on earlier versions the key is read from the `Extra`
-field, where [Better BibTeX](https://retorque.re/zotero-better-bibtex/) writes
-pinned keys as `Citation Key: doe2024example`.
 
 These can be discovered and accessed through any MCP client or through the [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector).
 
@@ -160,3 +149,24 @@ npx @modelcontextprotocol/inspector \
 - https://pyzotero.readthedocs.io/en/latest/
 - https://www.zotero.org/support/dev/web_api/v3/start
 - https://modelcontextprotocol.io/llms-full.txt can be utilized by LLMs
+
+## Appendix: Zotero version compatibility
+
+Item metadata is rendered from whatever fields the Zotero API returns rather
+than from a fixed list, so no version gating is needed. Fields an older Zotero
+lacks are simply omitted, and fields from schema versions newer than this
+server still appear, under an "Other Fields" heading, so upgrading Zotero never
+silently drops metadata.
+
+Citation keys are the main place this matters. Zotero 8 promoted `citationKey`
+to a native field on nearly every item type and migrated existing keys into it.
+Earlier versions expose it only on `preprint`, `dataset`, and `standard`, so
+elsewhere the key is read out of the `Extra` field, where
+[Better BibTeX](https://retorque.re/zotero-better-bibtex/) pins it as
+`Citation Key: doe2024example`. The native field takes precedence when both are
+present.
+
+Searching by citation key works against the local Zotero API, whose quick
+search indexes the field. The Zotero Web API does not index it, so the same
+query returns nothing there even though the field is present in the data it
+returns.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,19 @@ This project is a python server that implements the [Model Context Protocol (MCP
 This MCP server provides the following tools:
 
 - `zotero_search_items`: Search for items in your Zotero library using a text query
-- `zotero_item_metadata`: Get detailed metadata information about a specific Zotero item
+- `zotero_item_metadata`: Get the complete metadata for a specific Zotero item
 - `zotero_item_fulltext`: Get the full text of a specific Zotero item (i.e. PDF contents)
+
+`zotero_item_metadata` returns every populated field on the item, grouped into
+publication details, identifiers, timestamps, and library information. Fields
+from Zotero schema versions newer than this server are still rendered, so
+upgrading Zotero never silently drops metadata.
+
+Citation keys are included wherever they are available, both in search results
+and in item metadata. Zotero 8 and later expose `citationKey` as a native field
+on nearly every item type; on earlier versions the key is read from the `Extra`
+field, where [Better BibTeX](https://retorque.re/zotero-better-bibtex/) writes
+pinned keys as `Citation Key: doe2024example`.
 
 These can be discovered and accessed through any MCP client or through the [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector).
 

--- a/README.md
+++ b/README.md
@@ -150,23 +150,13 @@ npx @modelcontextprotocol/inspector \
 - https://www.zotero.org/support/dev/web_api/v3/start
 - https://modelcontextprotocol.io/llms-full.txt can be utilized by LLMs
 
-## Appendix: Zotero version compatibility
+## Appendix: notes on Zotero's API
 
-Item metadata is rendered from whatever fields the Zotero API returns rather
-than from a fixed list, so no version gating is needed. Fields an older Zotero
-lacks are simply omitted, and fields from schema versions newer than this
-server still appear, under an "Other Fields" heading, so upgrading Zotero never
+Item metadata is rendered from whatever fields the API returns rather than from
+a fixed list. Fields it omits are skipped, and fields this server doesn't know
+about appear under an "Other Fields" heading, so a Zotero upgrade never
 silently drops metadata.
 
-Citation keys are the main place this matters. Zotero 8 promoted `citationKey`
-to a native field on nearly every item type and migrated existing keys into it.
-Earlier versions expose it only on `preprint`, `dataset`, and `standard`, so
-elsewhere the key is read out of the `Extra` field, where
-[Better BibTeX](https://retorque.re/zotero-better-bibtex/) pins it as
-`Citation Key: doe2024example`. The native field takes precedence when both are
-present.
-
-Searching by citation key works against the local Zotero API, whose quick
-search indexes the field. The Zotero Web API does not index it, so the same
-query returns nothing there even though the field is present in the data it
-returns.
+The two APIs differ in one way worth knowing: the local API's quick search
+indexes citation keys, while the Web API does not, so searching for one returns
+nothing over the Web API even though the field is present in the data.

--- a/src/zotero_mcp/__init__.py
+++ b/src/zotero_mcp/__init__.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any, Literal
 
 from mcp.server import MCPServer
@@ -7,60 +8,298 @@ from zotero_mcp.client import get_attachment_details, get_zotero_client
 # Create an MCP server
 mcp = MCPServer("Zotero")
 
+# Zotero's local API omits empty fields while the web API returns them as "",
+# so every field lookup below treats absent and empty alike. That also keeps
+# rendering tolerant of older Zotero versions, whose schemas simply lack the
+# newer fields: citationKey only became available on nearly every item type in
+# the Zotero 8 era (before that just preprint/dataset/standard), and PMID/PMCID
+# arrived alongside it. Nothing here requires a field to exist.
+
+# Pinned Better BibTeX keys live in the Extra field as "Citation Key: foo2020bar"
+# on Zotero 7 and earlier. Zotero 8 promoted citationKey to a native field and
+# migrated those keys, so the native field wins when both are present.
+CITATION_KEY_IN_EXTRA = re.compile(
+    r"^Citation Key:\s*(\S+)\s*$", re.MULTILINE | re.IGNORECASE
+)
+
+# Venue fields ordered most- to least-specific: the first one present is the
+# item's source of record. Without this, anything that isn't a journal article
+# loses its provenance -- a preprint wouldn't report arXiv, a conference paper
+# wouldn't report its proceedings.
+SOURCE_FIELDS = (
+    "publicationTitle",
+    "bookTitle",
+    "proceedingsTitle",
+    "encyclopediaTitle",
+    "dictionaryTitle",
+    "websiteTitle",
+    "blogTitle",
+    "forumTitle",
+    "programTitle",
+    "conferenceName",
+    "repository",
+    "institution",
+    "university",
+    "publisher",
+)
+
+# Grouped rendering for the full metadata view. Any populated field missing from
+# this table still appears under "Other Fields", so fields from newer Zotero
+# schema versions surface without a code change here.
+FIELD_SECTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "Publication",
+        (
+            "publicationTitle",
+            "bookTitle",
+            "proceedingsTitle",
+            "conferenceName",
+            "encyclopediaTitle",
+            "dictionaryTitle",
+            "websiteTitle",
+            "websiteType",
+            "blogTitle",
+            "forumTitle",
+            "postType",
+            "programTitle",
+            "network",
+            "repository",
+            "repositoryLocation",
+            "institution",
+            "university",
+            "thesisType",
+            "publisher",
+            "place",
+            "edition",
+            "series",
+            "seriesTitle",
+            "seriesNumber",
+            "seriesText",
+            "volume",
+            "numberOfVolumes",
+            "issue",
+            "section",
+            "pages",
+            "numPages",
+            "journalAbbreviation",
+            "reportNumber",
+            "reportType",
+            "medium",
+            "runningTime",
+        ),
+    ),
+    (
+        "Identifiers",
+        (
+            "url",
+            "DOI",
+            "ISBN",
+            "ISSN",
+            "PMID",
+            "PMCID",
+            "archiveID",
+            "callNumber",
+        ),
+    ),
+    (
+        "Timestamps",
+        (
+            "dateAdded",
+            "dateModified",
+            "accessDate",
+            "lastRead",
+            "filingDate",
+            "priorityDate",
+        ),
+    ),
+    (
+        "Library",
+        (
+            "libraryCatalog",
+            "archive",
+            "archiveLocation",
+            "rights",
+            "language",
+            "shortTitle",
+        ),
+    ),
+    (
+        "File",
+        (
+            "contentType",
+            "filename",
+            "linkMode",
+            "charset",
+            "md5",
+            "mtime",
+            "path",
+        ),
+    ),
+)
+
+# Labels that camelCase splitting alone would get wrong or render awkwardly.
+FIELD_LABELS = {
+    "url": "URL",
+    "publicationTitle": "Publication",
+    "numPages": "Number of Pages",
+    "numberOfVolumes": "Number of Volumes",
+    "accessDate": "Accessed",
+    "archiveID": "Archive ID",
+    "md5": "MD5",
+    "mtime": "File Modified",
+}
+
+SECTIONED_FIELDS = frozenset(field for _, fields in FIELD_SECTIONS for field in fields)
+
+# Fields with dedicated rendering, excluded from the "Other Fields" catch-all.
+SPECIAL_FIELDS = frozenset(
+    {
+        "key",
+        "version",
+        "itemType",
+        "title",
+        "date",
+        "citationKey",
+        "creators",
+        "abstractNote",
+        "tags",
+        "extra",
+        "note",
+        "parentItem",
+        "relations",
+        "collections",
+        "annotationType",
+        "annotationText",
+        "annotationComment",
+        "annotationColor",
+        "annotationPageLabel",
+        "annotationAuthorName",
+        "annotationSortIndex",
+        "annotationPosition",
+    }
+)
+
+
+def get_citation_key(data: dict[str, Any]) -> str | None:
+    """Get an item's citation key, falling back to a Better BibTeX pinned key"""
+    if citation_key := data.get("citationKey"):
+        return citation_key
+    if match := CITATION_KEY_IN_EXTRA.search(data.get("extra", "")):
+        return match.group(1)
+    return None
+
+
+def get_source(data: dict[str, Any]) -> str | None:
+    """Get the item's source of record, e.g. its journal, book, or repository"""
+    for field in SOURCE_FIELDS:
+        if value := data.get(field):
+            return f"In: {value}" if field == "bookTitle" else value
+    return None
+
+
+def field_label(field: str) -> str:
+    """Get the display label for a Zotero field name"""
+    if label := FIELD_LABELS.get(field):
+        return label
+    if field.isupper():
+        return field
+    spaced = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", " ", field)
+    return spaced[0].upper() + spaced[1:]
+
+
+def format_fields(data: dict[str, Any], fields: Any) -> list[str]:
+    """Render populated fields as label/value lines, skipping empty ones"""
+    return [
+        f"{field_label(field)}: {data[field]}" for field in fields if data.get(field)
+    ]
+
+
+def strip_note_html(note: str) -> str:
+    """Convert Zotero's HTML note content to rough markdown"""
+    note = note.replace("<p>", "").replace("</p>", "\n").replace("<br>", "\n")
+    note = note.replace("<strong>", "**").replace("</strong>", "**")
+    return note.replace("<em>", "*").replace("</em>", "*")
+
+
+def format_tags(data: dict[str, Any]) -> str | None:
+    """Render an item's tags as a markdown section"""
+    if not (tags := data.get("tags")):
+        return None
+    return "\n### Tags\n" + ", ".join(f"`{tag['tag']}`" for tag in tags)
+
+
+def format_note(item: dict[str, Any]) -> str:
+    """Format a Zotero note item"""
+    data = item["data"]
+
+    formatted = [
+        "## 📝 Note",
+        f"Item Key: `{item['key']}`",
+    ]
+    if parent_item := data.get("parentItem"):
+        formatted.append(f"Parent Item: `{parent_item}`")
+    if date := data.get("dateModified"):
+        formatted.append(f"Last Modified: {date}")
+    if tags := format_tags(data):
+        formatted.append(tags)
+
+    formatted.append(f"\n### Note Content\n{strip_note_html(data.get('note', ''))}")
+
+    return "\n".join(formatted)
+
+
+def format_annotation(item: dict[str, Any]) -> str:
+    """Format a Zotero annotation item, i.e. a PDF highlight or comment"""
+    data = item["data"]
+    annotation_type = data.get("annotationType", "annotation")
+
+    formatted = [
+        f"## 🖍 {annotation_type.capitalize()} Annotation",
+        f"Item Key: `{item['key']}`",
+    ]
+    if parent_item := data.get("parentItem"):
+        formatted.append(f"Parent Item: `{parent_item}`")
+    if page := data.get("annotationPageLabel"):
+        formatted.append(f"Page: {page}")
+    if color := data.get("annotationColor"):
+        formatted.append(f"Color: {color}")
+    if author := data.get("annotationAuthorName"):
+        formatted.append(f"Author: {author}")
+    if date := data.get("dateModified"):
+        formatted.append(f"Last Modified: {date}")
+    if tags := format_tags(data):
+        formatted.append(tags)
+
+    if text := data.get("annotationText"):
+        formatted.append(f"\n### Highlighted Text\n{text}")
+    if comment := data.get("annotationComment"):
+        formatted.append(f"\n### Comment\n{comment}")
+
+    return "\n".join(formatted)
+
 
 def format_item(item: dict[str, Any]) -> str:
-    """Format a Zotero item's metadata as a readable string optimized for LLM consumption"""
+    """Format a Zotero item's full metadata as a string optimized for LLM consumption"""
     data = item["data"]
-    item_key = item["key"]
     item_type = data.get("itemType", "unknown")
 
-    # Special handling for notes
     if item_type == "note":
-        # Get note content
-        note_content = data.get("note", "")
-        # Strip HTML tags for cleaner text (simple approach)
-        note_content = (
-            note_content.replace("<p>", "").replace("</p>", "\n").replace("<br>", "\n")
-        )
-        note_content = note_content.replace("<strong>", "**").replace("</strong>", "**")
-        note_content = note_content.replace("<em>", "*").replace("</em>", "*")
+        return format_note(item)
+    if item_type == "annotation":
+        return format_annotation(item)
 
-        # Format note with clear sections
-        formatted = [
-            "## 📝 Note",
-            f"Item Key: `{item_key}`",
-        ]
-
-        # Add parent item reference if available
-        if parent_item := data.get("parentItem"):
-            formatted.append(f"Parent Item: `{parent_item}`")
-
-        # Add date if available
-        if date := data.get("dateModified"):
-            formatted.append(f"Last Modified: {date}")
-
-        # Add tags with formatting for better visibility
-        if tags := data.get("tags"):
-            tag_list = [f"`{tag['tag']}`" for tag in tags]
-            formatted.append(f"\n### Tags\n{', '.join(tag_list)}")
-
-        # Add note content
-        formatted.append(f"\n### Note Content\n{note_content}")
-
-        return "\n".join(formatted)
-
-    # Regular item handling (non-notes)
-
-    # Basic metadata with key for easy reference
-    formatted = [
-        f"## {data.get('title', 'Untitled')}",
-        f"Item Key: `{item_key}`",
+    # Identity first: the item key addresses the item through this API, the
+    # citation key addresses it from a manuscript.
+    formatted = [f"## {data.get('title', 'Untitled')}", f"Item Key: `{item['key']}`"]
+    if citation_key := get_citation_key(data):
+        formatted.append(f"Citation Key: `{citation_key}`")
+    formatted += [
         f"Type: {item_type}",
         f"Date: {data.get('date', 'No date')}",
     ]
 
     # Creators with role differentiation
-    creators_by_role = {}
+    creators_by_role: dict[str, list[str]] = {}
     for creator in data.get("creators", []):
         role = creator.get("creatorType", "contributor")
         name = ""
@@ -70,60 +309,56 @@ def format_item(item: dict[str, Any]) -> str:
             name = creator["name"]
 
         if name:
-            if role not in creators_by_role:
-                creators_by_role[role] = []
-            creators_by_role[role].append(name)
+            creators_by_role.setdefault(role, []).append(name)
 
     for role, names in creators_by_role.items():
         role_display = role.capitalize() + ("s" if len(names) > 1 else "")
         formatted.append(f"{role_display}: {'; '.join(names)}")
 
-    # Publication details
-    if publication := data.get("publicationTitle"):
-        formatted.append(f"Publication: {publication}")
-    if volume := data.get("volume"):
-        volume_info = f"Volume: {volume}"
-        if issue := data.get("issue"):
-            volume_info += f", Issue: {issue}"
-        if pages := data.get("pages"):
-            volume_info += f", Pages: {pages}"
-        formatted.append(volume_info)
-
-    # Abstract with clear section header
     if abstract := data.get("abstractNote"):
         formatted.append(f"\n### Abstract\n{abstract}")
 
-    # Tags with formatting for better visibility
-    if tags := data.get("tags"):
-        tag_list = [f"`{tag['tag']}`" for tag in tags]
-        formatted.append(f"\n### Tags\n{', '.join(tag_list)}")
+    if tags := format_tags(data):
+        formatted.append(tags)
 
-    # URLs, DOIs, and identifiers grouped together
-    identifiers = []
-    if url := data.get("url"):
-        identifiers.append(f"URL: {url}")
-    if doi := data.get("DOI"):
-        identifiers.append(f"DOI: {doi}")
-    if isbn := data.get("ISBN"):
-        identifiers.append(f"ISBN: {isbn}")
-    if issn := data.get("ISSN"):
-        identifiers.append(f"ISSN: {issn}")
+    for heading, fields in FIELD_SECTIONS:
+        if lines := format_fields(data, fields):
+            formatted.append(f"\n### {heading}\n" + "\n".join(lines))
 
-    if identifiers:
-        formatted.append("\n### Identifiers\n" + "\n".join(identifiers))
+    # Extra holds free-form metadata, including CSL variables and (on Zotero 7
+    # and earlier) the pinned citation key already surfaced above.
+    if extra := data.get("extra"):
+        formatted.append(f"\n### Extra\n{extra}")
 
-    # Notes and attachments
-    if notes := item.get("meta", {}).get("numChildren", 0):
-        formatted.append(
-            f"\n### Additional Information\nNumber of notes/attachments: {notes}"
+    # Catch-all so fields from newer schema versions are never silently dropped.
+    unrendered = sorted(set(data) - SECTIONED_FIELDS - SPECIAL_FIELDS)
+    if lines := format_fields(data, unrendered):
+        formatted.append("\n### Other Fields\n" + "\n".join(lines))
+
+    additional = []
+    if num_children := item.get("meta", {}).get("numChildren"):
+        additional.append(f"Number of notes/attachments: {num_children}")
+    if parsed_date := item.get("meta", {}).get("parsedDate"):
+        additional.append(f"Parsed Date: {parsed_date}")
+    if parent_item := data.get("parentItem"):
+        additional.append(f"Parent Item: `{parent_item}`")
+    if collections := data.get("collections"):
+        additional.append(
+            "Collections: " + ", ".join(f"`{key}`" for key in collections)
         )
+    if library_name := item.get("library", {}).get("name"):
+        additional.append(f"Library: {library_name}")
+    if version := data.get("version"):
+        additional.append(f"Version: {version}")
+    if additional:
+        formatted.append("\n### Additional Information\n" + "\n".join(additional))
 
     return "\n".join(formatted)
 
 
 @mcp.tool(
     name="zotero_item_metadata",
-    description="Get metadata information about a specific Zotero item, given the item key.",
+    description="Get the complete metadata for a specific Zotero item, given the item key. Includes the citation key, publication details, identifiers, and timestamps.",
 )
 def get_item_metadata(item_key: str) -> str:
     """Get metadata information about a specific Zotero item"""
@@ -231,18 +466,7 @@ def search_items(
 
         # Special handling for notes
         if item_type == "note":
-            # Get note content
-            note_content = data.get("note", "")
-            # Strip HTML tags for cleaner text (simple approach)
-            note_content = (
-                note_content.replace("<p>", "")
-                .replace("</p>", "\n")
-                .replace("<br>", "\n")
-            )
-            note_content = note_content.replace("<strong>", "**").replace(
-                "</strong>", "**"
-            )
-            note_content = note_content.replace("<em>", "*").replace("</em>", "*")
+            note_content = strip_note_html(data.get("note", ""))
 
             # Extract a title from the first line if possible, otherwise use first few words
             title_preview = ""
@@ -303,28 +527,22 @@ def search_items(
 
         creator_str = "; ".join(creators) if creators else "No authors"
 
-        # Get publication or source info
-        source = ""
-        if pub := data.get("publicationTitle"):
-            source = pub
-        elif book := data.get("bookTitle"):
-            source = f"In: {book}"
-        elif publisher := data.get("publisher"):
-            source = f"{publisher}"
-
         # Get a brief abstract (truncated if too long)
         abstract = data.get("abstractNote", "")
         if len(abstract) > 150:
             abstract = abstract[:147] + "..."
 
         # Build formatted entry with markdown for better structure
+        key_line = f"**Type**: {item_type} | **Date**: {date} | **Key**: `{item_key}`"
+        if citation_key := get_citation_key(data):
+            key_line += f" | **Citation Key**: `{citation_key}`"
         entry = [
             f"## {i + 1}. {title}",
-            f"**Type**: {item_type} | **Date**: {date} | **Key**: `{item_key}`",
+            key_line,
             f"**Authors**: {creator_str}",
         ]
 
-        if source:
+        if source := get_source(data):
             entry.append(f"**Source**: {source}")
 
         if abstract:

--- a/src/zotero_mcp/__init__.py
+++ b/src/zotero_mcp/__init__.py
@@ -1,7 +1,8 @@
 import re
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from mcp.server import MCPServer
+from pydantic import Field
 
 from zotero_mcp.client import get_attachment_details, get_zotero_client
 
@@ -424,16 +425,71 @@ def get_item_fulltext(item_key: str) -> str:
         return f"Error retrieving item full text: {e!s}"
 
 
+# Search behaviour below was verified against both a local Zotero API and
+# api.zotero.org rather than taken from the docs, which are thin and in one
+# respect outdated: https://www.zotero.org/support/dev/web_api/v3/basics#searching
+# says quick search "currently supports phrase searching only", but both APIs
+# actually match items containing all the query's words in any position.
 @mcp.tool(
     name="zotero_search_items",
-    # More detail can be added if useful: https://www.zotero.org/support/dev/web_api/v3/basics#searching
-    description="Search for items in your Zotero library, given a query string, query mode (titleCreatorYear or everything), and optional tag search (supports boolean searches). Returned results can be looked up with zotero_item_fulltext or zotero_item_metadata.",
+    description=(
+        "Search for items in your Zotero library. Returns a summary of each match; "
+        "look up individual results with zotero_item_metadata or zotero_item_fulltext."
+        "\n\n"
+        "Choosing a query mode:\n"
+        "- 'titleCreatorYear' (the default) searches titles, creator names, and years. "
+        "Use it for known-item lookup, where you know roughly what the item is called "
+        "or who wrote it.\n"
+        "- 'everything' additionally searches abstracts, the Extra field, note text, "
+        "and the full text of attachments. Use it for topic and full-text search, "
+        "where the term would not appear in a title.\n\n"
+        "Words match by prefix and multi-word queries match items containing all of "
+        "the words in any position, so 'cybor insect' matches 'Cyborg Insect'."
+    ),
 )
 def search_items(
-    query: str,
-    qmode: Literal["titleCreatorYear", "everything"] | None = "titleCreatorYear",
-    tag: str | None = None,
-    limit: int | None = 10,
+    query: Annotated[
+        str,
+        Field(
+            description=(
+                "Text to match. Words match by prefix, and an item must contain every "
+                "word in the query, though not necessarily as a contiguous phrase."
+            )
+        ),
+    ],
+    qmode: Annotated[
+        Literal["titleCreatorYear", "everything"] | None,
+        Field(
+            description=(
+                "Which fields to search. 'titleCreatorYear' covers titles, creator "
+                "names, and years; against a local Zotero API it also matches citation "
+                "keys, which the Zotero Web API does not index. 'everything' adds "
+                "abstracts, the Extra field, notes, and attachment full text, but its "
+                "results also include matching attachments and notes as separate "
+                "entries, which commonly outnumber the parent items -- raise 'limit' "
+                "to compensate."
+            )
+        ),
+    ] = "titleCreatorYear",
+    tag: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Filter by tag. Use 'foo || bar' to match either tag and '-foo' to "
+                "exclude one; tag names containing spaces are matched as written. "
+                "Requiring two tags at once is not expressible here."
+            )
+        ),
+    ] = None,
+    limit: Annotated[
+        int | None,
+        Field(
+            description=(
+                "Maximum number of results. Worth raising when qmode is 'everything', "
+                "whose results are padded with child attachments and notes."
+            )
+        ),
+    ] = 10,
 ) -> str:
     """Search for items in your Zotero library"""
     zot = get_zotero_client()

--- a/src/zotero_mcp/__init__.py
+++ b/src/zotero_mcp/__init__.py
@@ -10,18 +10,9 @@ from zotero_mcp.client import get_attachment_details, get_zotero_client
 mcp = MCPServer("Zotero")
 
 # Zotero's local API omits empty fields while the web API returns them as "",
-# so every field lookup below treats absent and empty alike. That also keeps
-# rendering tolerant of older Zotero versions, whose schemas simply lack the
-# newer fields: citationKey only became available on nearly every item type in
-# the Zotero 8 era (before that just preprint/dataset/standard), and PMID/PMCID
-# arrived alongside it. Nothing here requires a field to exist.
-
-# Pinned Better BibTeX keys live in the Extra field as "Citation Key: foo2020bar"
-# on Zotero 7 and earlier. Zotero 8 promoted citationKey to a native field and
-# migrated those keys, so the native field wins when both are present.
-CITATION_KEY_IN_EXTRA = re.compile(
-    r"^Citation Key:\s*(\S+)\s*$", re.MULTILINE | re.IGNORECASE
-)
+# so every field lookup below treats absent and empty alike. Nothing here
+# requires a field to exist, which is also what keeps rendering tolerant of
+# schema differences between Zotero versions.
 
 # Venue fields ordered most- to least-specific: the first one present is the
 # item's source of record. Without this, anything that isn't a journal article
@@ -181,15 +172,6 @@ SPECIAL_FIELDS = frozenset(
 )
 
 
-def get_citation_key(data: dict[str, Any]) -> str | None:
-    """Get an item's citation key, falling back to a Better BibTeX pinned key"""
-    if citation_key := data.get("citationKey"):
-        return citation_key
-    if match := CITATION_KEY_IN_EXTRA.search(data.get("extra", "")):
-        return match.group(1)
-    return None
-
-
 def get_source(data: dict[str, Any]) -> str | None:
     """Get the item's source of record, e.g. its journal, book, or repository"""
     for field in SOURCE_FIELDS:
@@ -292,7 +274,7 @@ def format_item(item: dict[str, Any]) -> str:
     # Identity first: the item key addresses the item through this API, the
     # citation key addresses it from a manuscript.
     formatted = [f"## {data.get('title', 'Untitled')}", f"Item Key: `{item['key']}`"]
-    if citation_key := get_citation_key(data):
+    if citation_key := data.get("citationKey"):
         formatted.append(f"Citation Key: `{citation_key}`")
     formatted += [
         f"Type: {item_type}",
@@ -326,8 +308,8 @@ def format_item(item: dict[str, Any]) -> str:
         if lines := format_fields(data, fields):
             formatted.append(f"\n### {heading}\n" + "\n".join(lines))
 
-    # Extra holds free-form metadata, including CSL variables and (on Zotero 7
-    # and earlier) the pinned citation key already surfaced above.
+    # Extra holds free-form metadata, including CSL variables that have no
+    # dedicated Zotero field.
     if extra := data.get("extra"):
         formatted.append(f"\n### Extra\n{extra}")
 
@@ -592,7 +574,7 @@ def search_items(
 
         # Build formatted entry with markdown for better structure
         key_line = f"**Type**: {item_type} | **Date**: {date} | **Key**: `{item_key}`"
-        if citation_key := get_citation_key(data):
+        if citation_key := data.get("citationKey"):
             key_line += f" | **Citation Key**: `{citation_key}`"
         entry = [
             f"## {i + 1}. {title}",

--- a/src/zotero_mcp/__init__.py
+++ b/src/zotero_mcp/__init__.py
@@ -464,10 +464,11 @@ def search_items(
                 "Which fields to search. 'titleCreatorYear' covers titles, creator "
                 "names, and years; against a local Zotero API it also matches citation "
                 "keys, which the Zotero Web API does not index. 'everything' adds "
-                "abstracts, the Extra field, notes, and attachment full text, but its "
-                "results also include matching attachments and notes as separate "
-                "entries, which commonly outnumber the parent items -- raise 'limit' "
-                "to compensate."
+                "abstracts, the Extra field, note text, and attachment full text, so "
+                "use it to find work by what is written inside the PDF rather than in "
+                "its metadata. A match inside an attachment or note is returned as "
+                "that child item rather than as its parent, so results routinely "
+                "contain more entries than distinct works."
             )
         ),
     ] = "titleCreatorYear",
@@ -486,7 +487,8 @@ def search_items(
         Field(
             description=(
                 "Maximum number of results. Worth raising when qmode is 'everything', "
-                "whose results are padded with child attachments and notes."
+                "where several attachments or notes belonging to one work can each "
+                "match separately."
             )
         ),
     ] = 10,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,43 @@ def sample_item() -> dict[str, Any]:
 
 
 @pytest.fixture
+def sample_annotation() -> dict[str, Any]:
+    """Fixture that returns a sample Zotero annotation item"""
+    return {
+        "key": "ANNO1234",
+        "data": {
+            "key": "ANNO1234",
+            "itemType": "annotation",
+            "parentItem": "XYZ789",
+            "annotationType": "highlight",
+            "annotationText": "The highlighted passage",
+            "annotationComment": "A comment on the passage",
+            "annotationColor": "#2ea8e5",
+            "annotationPageLabel": "7",
+            "dateModified": "2024-01-01T00:00:00Z",
+            "tags": [{"tag": "important"}],
+        },
+    }
+
+
+@pytest.fixture
+def legacy_item() -> dict[str, Any]:
+    """Sample item as an older Zotero returns it: no citationKey, no PMID/PMCID,
+    and a Better BibTeX citation key pinned into the Extra field."""
+    return {
+        "key": "OLD12345",
+        "data": {
+            "key": "OLD12345",
+            "itemType": "journalArticle",
+            "title": "Legacy Article",
+            "date": "2019",
+            "publicationTitle": "Journal of Legacy Studies",
+            "extra": "Citation Key: doe2019legacy\nPMID: 12345678",
+        },
+    }
+
+
+@pytest.fixture
 def sample_attachment() -> dict[str, Any]:
     """Fixture that returns a sample Zotero attachment item"""
     return {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,18 +63,16 @@ def sample_annotation() -> dict[str, Any]:
 
 
 @pytest.fixture
-def legacy_item() -> dict[str, Any]:
-    """Sample item as an older Zotero returns it: no citationKey, no PMID/PMCID,
-    and a Better BibTeX citation key pinned into the Extra field."""
+def sparse_item() -> dict[str, Any]:
+    """Sample item with only a handful of fields populated"""
     return {
-        "key": "OLD12345",
+        "key": "SPARSE01",
         "data": {
-            "key": "OLD12345",
+            "key": "SPARSE01",
             "itemType": "journalArticle",
-            "title": "Legacy Article",
+            "title": "Sparse Article",
             "date": "2019",
-            "publicationTitle": "Journal of Legacy Studies",
-            "extra": "Citation Key: doe2019legacy\nPMID: 12345678",
+            "publicationTitle": "Journal of Sparse Studies",
         },
     }
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -4,33 +4,18 @@ from typing import Any
 
 import pytest
 
-from zotero_mcp import format_item, get_citation_key, get_source
+from zotero_mcp import format_item, get_source
 
 
-def test_citation_key_native_field(sample_item: dict[str, Any]) -> None:
-    """Zotero 8+ exposes citationKey as a native field"""
+def test_citation_key_rendered(sample_item: dict[str, Any]) -> None:
+    """The citation key is surfaced alongside the item key"""
     sample_item["data"]["citationKey"] = "doe2024test"
 
-    assert get_citation_key(sample_item["data"]) == "doe2024test"
     assert "Citation Key: `doe2024test`" in format_item(sample_item)
-
-
-def test_citation_key_from_extra(legacy_item: dict[str, Any]) -> None:
-    """Older Zotero versions only have Better BibTeX's pinned key in Extra"""
-    assert get_citation_key(legacy_item["data"]) == "doe2019legacy"
-    assert "Citation Key: `doe2019legacy`" in format_item(legacy_item)
-
-
-def test_citation_key_native_field_wins(legacy_item: dict[str, Any]) -> None:
-    """Zotero 8 migrated pinned keys, so the native field takes precedence"""
-    legacy_item["data"]["citationKey"] = "migrated2019key"
-
-    assert get_citation_key(legacy_item["data"]) == "migrated2019key"
 
 
 def test_citation_key_absent(sample_item: dict[str, Any]) -> None:
     """Items without a citation key render no Citation Key line"""
-    assert get_citation_key(sample_item["data"]) is None
     assert "Citation Key" not in format_item(sample_item)
 
 
@@ -105,12 +90,12 @@ def test_unknown_future_field_still_rendered(sample_item: dict[str, Any]) -> Non
     assert "Some Future Field: future value" in result
 
 
-def test_legacy_item_renders_without_newer_fields(legacy_item: dict[str, Any]) -> None:
-    """An older Zotero payload renders cleanly, omitting sections it can't fill"""
-    result = format_item(legacy_item)
+def test_sparse_item_omits_empty_sections(sparse_item: dict[str, Any]) -> None:
+    """A payload with few fields renders cleanly, omitting sections it can't fill"""
+    result = format_item(sparse_item)
 
-    assert "## Legacy Article" in result
-    assert "Publication: Journal of Legacy Studies" in result
+    assert "## Sparse Article" in result
+    assert "Publication: Journal of Sparse Studies" in result
     # No populated fields for these sections, so they are omitted entirely.
     assert "### Timestamps" not in result
     assert "### File" not in result

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,156 @@
+"""Tests for item metadata formatting, including cross-version compatibility"""
+
+from typing import Any
+
+import pytest
+
+from zotero_mcp import format_item, get_citation_key, get_source
+
+
+def test_citation_key_native_field(sample_item: dict[str, Any]) -> None:
+    """Zotero 8+ exposes citationKey as a native field"""
+    sample_item["data"]["citationKey"] = "doe2024test"
+
+    assert get_citation_key(sample_item["data"]) == "doe2024test"
+    assert "Citation Key: `doe2024test`" in format_item(sample_item)
+
+
+def test_citation_key_from_extra(legacy_item: dict[str, Any]) -> None:
+    """Older Zotero versions only have Better BibTeX's pinned key in Extra"""
+    assert get_citation_key(legacy_item["data"]) == "doe2019legacy"
+    assert "Citation Key: `doe2019legacy`" in format_item(legacy_item)
+
+
+def test_citation_key_native_field_wins(legacy_item: dict[str, Any]) -> None:
+    """Zotero 8 migrated pinned keys, so the native field takes precedence"""
+    legacy_item["data"]["citationKey"] = "migrated2019key"
+
+    assert get_citation_key(legacy_item["data"]) == "migrated2019key"
+
+
+def test_citation_key_absent(sample_item: dict[str, Any]) -> None:
+    """Items without a citation key render no Citation Key line"""
+    assert get_citation_key(sample_item["data"]) is None
+    assert "Citation Key" not in format_item(sample_item)
+
+
+@pytest.mark.parametrize(
+    ("item_type", "fields", "expected"),
+    [
+        ("journalArticle", {"publicationTitle": "Nature"}, "Nature"),
+        ("preprint", {"repository": "arXiv"}, "arXiv"),
+        ("conferencePaper", {"proceedingsTitle": "WACV 2023"}, "WACV 2023"),
+        ("bookSection", {"bookTitle": "A Book", "publisher": "Pub"}, "In: A Book"),
+        ("book", {"publisher": "Pub"}, "Pub"),
+        ("blogPost", {"blogTitle": "A Blog"}, "A Blog"),
+        ("webpage", {"websiteTitle": "A Site"}, "A Site"),
+        ("report", {"institution": "An Institute"}, "An Institute"),
+        ("thesis", {"university": "A University"}, "A University"),
+        ("manuscript", {}, None),
+    ],
+)
+def test_get_source_by_item_type(
+    item_type: str, fields: dict[str, str], expected: str | None
+) -> None:
+    """Every item type reports its own source of record, not just journals"""
+    assert get_source({"itemType": item_type, **fields}) == expected
+
+
+def test_source_rendered_for_non_journal_items(sample_item: dict[str, Any]) -> None:
+    """A preprint surfaces its repository in the full metadata view"""
+    sample_item["data"]["itemType"] = "preprint"
+    sample_item["data"]["repository"] = "arXiv"
+    sample_item["data"]["archiveID"] = "arXiv:2401.00001"
+
+    result = format_item(sample_item)
+
+    assert "Repository: arXiv" in result
+    assert "Archive ID: arXiv:2401.00001" in result
+
+
+def test_timestamps_included(sample_item: dict[str, Any]) -> None:
+    """The single-item view reports provenance timestamps"""
+    sample_item["data"]["dateAdded"] = "2024-01-01T00:00:00Z"
+    sample_item["data"]["dateModified"] = "2024-02-02T00:00:00Z"
+    sample_item["data"]["accessDate"] = "2024-03-03T00:00:00Z"
+
+    result = format_item(sample_item)
+
+    assert "### Timestamps" in result
+    assert "Date Added: 2024-01-01T00:00:00Z" in result
+    assert "Date Modified: 2024-02-02T00:00:00Z" in result
+    assert "Accessed: 2024-03-03T00:00:00Z" in result
+
+
+def test_extra_and_identifiers(sample_item: dict[str, Any]) -> None:
+    """Extra is surfaced verbatim and newer identifiers are grouped"""
+    sample_item["data"]["extra"] = "arXiv:2401.00001 [cs.LG]"
+    sample_item["data"]["PMID"] = "12345678"
+    sample_item["data"]["PMCID"] = "PMC1234567"
+
+    result = format_item(sample_item)
+
+    assert "### Extra\narXiv:2401.00001 [cs.LG]" in result
+    assert "PMID: 12345678" in result
+    assert "PMCID: PMC1234567" in result
+
+
+def test_unknown_future_field_still_rendered(sample_item: dict[str, Any]) -> None:
+    """Fields from newer schema versions surface without a code change"""
+    sample_item["data"]["someFutureField"] = "future value"
+
+    result = format_item(sample_item)
+
+    assert "### Other Fields" in result
+    assert "Some Future Field: future value" in result
+
+
+def test_legacy_item_renders_without_newer_fields(legacy_item: dict[str, Any]) -> None:
+    """An older Zotero payload renders cleanly, omitting sections it can't fill"""
+    result = format_item(legacy_item)
+
+    assert "## Legacy Article" in result
+    assert "Publication: Journal of Legacy Studies" in result
+    # No populated fields for these sections, so they are omitted entirely.
+    assert "### Timestamps" not in result
+    assert "### File" not in result
+    assert "### Other Fields" not in result
+
+
+def test_minimal_item_does_not_raise() -> None:
+    """A payload with almost nothing in it still formats"""
+    result = format_item({"key": "MIN00001", "data": {"itemType": "document"}})
+
+    assert "Item Key: `MIN00001`" in result
+    assert "Untitled" in result
+
+
+def test_format_annotation(sample_annotation: dict[str, Any]) -> None:
+    """Annotations render their highlighted text rather than an empty stub"""
+    result = format_item(sample_annotation)
+
+    assert "Highlight Annotation" in result
+    assert "Item Key: `ANNO1234`" in result
+    assert "Parent Item: `XYZ789`" in result
+    assert "Page: 7" in result
+    assert "### Highlighted Text\nThe highlighted passage" in result
+    assert "### Comment\nA comment on the passage" in result
+    assert "`important`" in result
+
+
+def test_format_note_unchanged(sample_item: dict[str, Any]) -> None:
+    """Notes keep their dedicated rendering"""
+    note = {
+        "key": "NOTE1234",
+        "data": {
+            "itemType": "note",
+            "note": "<p>A <strong>note</strong> body</p>",
+            "parentItem": "ABCD1234",
+        },
+    }
+
+    result = format_item(note)
+
+    assert "## 📝 Note" in result
+    assert "Parent Item: `ABCD1234`" in result
+    assert "A **note** body" in result

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -22,6 +22,31 @@ def test_search_items_basic(mock_zotero: Any, sample_item: dict[str, Any]) -> No
     )
 
 
+def test_search_items_includes_citation_key(
+    mock_zotero: Any, sample_item: dict[str, Any]
+) -> None:
+    """Search results carry the citation key so no follow-up lookup is needed"""
+    sample_item["data"]["citationKey"] = "doe2024test"
+    mock_zotero.items.return_value = [sample_item]
+
+    result = search_items("test")
+
+    assert "**Citation Key**: `doe2024test`" in result
+
+
+def test_search_items_source_for_non_journal(
+    mock_zotero: Any, sample_item: dict[str, Any]
+) -> None:
+    """Search summaries report a source for item types beyond journal articles"""
+    sample_item["data"]["itemType"] = "preprint"
+    sample_item["data"]["repository"] = "arXiv"
+    mock_zotero.items.return_value = [sample_item]
+
+    result = search_items("test")
+
+    assert "**Source**: arXiv" in result
+
+
 def test_search_items_no_results(mock_zotero: Any) -> None:
     """Test search with no results"""
     mock_zotero.items.return_value = []


### PR DESCRIPTION
Closes #18.

## Why

#18 asked a narrow question — how do you get an item's citation key? Answering
it meant auditing what this server actually renders, and the citation key turned
out to be the least of it.

Against a real 600-item library, `format_item()` was dropping most of what
Zotero returns. It read `publicationTitle` and nothing else for venue, so every
item type other than a journal article lost its source of record. Only 54 of 215
non-attachment items were journal articles; the other ~75% — 81 preprints, 33
webpages, 11 conference papers, 10 books — rendered with no indication of where
they were published. A preprint reported `Type: preprint` and never mentioned
arXiv. Annotations had no branch at all, falling through to the regular path and
rendering as `## Untitled` with the highlighted text discarded. Timestamps,
`Extra`, `PMID`/`PMCID`, and attachment file details were dropped everywhere.

There was also live drift between the two renderers: `search_items()` handled
`bookTitle` and `publisher` while `format_item()` did not, so for a book the
*search summary* told you more than the *full metadata* call. They now share one
`get_source()`.

Since `zotero_item_metadata` is the drill-down call, it now returns every
populated field rather than a curated subset. `search_items` stays a lean
summary and gains only the citation key and a correct source line.

## What changed

One commit, with the full rationale in its body. See commit for review.

The one cross-cutting decision worth knowing up front: **no field is ever
required, and unrecognized fields are rendered rather than dropped.** That's
what makes this work across Zotero versions without any version gating — see
below.

## Compatibility

Zotero 7 and earlier are explicitly **not** supported for citation keys, which
is worth stating because the history is misleading. `citationKey` is *not* a
Zotero 8 invention, but for practical purposes it may as well be — diffing real
schema snapshots from
[zotero/zotero-schema](https://github.com/zotero/zotero-schema):

| Schema | Date | `citationKey` available on |
| --- | --- | --- |
| v12 | 2021-03 | 0/37 item types |
| v14 | 2021-11 | 1/38 — `preprint` only |
| v28–v33 | 2023-04 → 2025-01 | 3/40 — `+dataset`, `+standard` |
| v33 (Zotero 8 era) | 2025-12 | **37/40** |
| v44 | 2026-07 | 37/40 |

On Zotero 7 the field is effectively absent for ordinary items and the key
lives in `Extra`, where Better BibTeX pins it. An earlier revision of this
branch read that as a fallback; it was dropped as not worth the regex, the
precedence rule between two sources, or the tests pinning down which wins.
`PMID`/`PMCID` arrived in the same 2025-12 update and are likewise read only
where Zotero provides them.

Everything else stays version-agnostic without any gating, because no field is
ever required:

1. Absent and empty are treated alike — which also covers the local API omitting
   empty fields while the web API returns `""`.
2. Fields not in the section table render under `Other Fields`, so a Zotero
   upgrade surfaces new metadata without a code change here.

Incidental finding worth recording: `api.zotero.org/schema?version=N` silently
ignores the parameter and always returns the current schema, so historical
comparison has to go through the `zotero-schema` git history.

## Validation

- 33 tests pass; `ruff check` and `ruff format --check` clean.
- New tests cover a sparse payload whose empty sections must be omitted, and a
  synthetic future field that must surface under `Other Fields`.
- Rendered live against a local Zotero 9.0-beta.21 library for `preprint`,
  `annotation`, `conferencePaper`, `book`, and `attachment`, asserting no
  populated field goes unrendered for any of them.
- Confirmed `citationKey` is *returned* by both the local API and
  `api.zotero.org` (verified against a real web-API item fetch), so rendering is
  not local-API-only. Searching by it is — see below.
- Verified end-to-end against two items with real citation keys set
  (`kimiK2`, `kimiK25`): the key renders in both `zotero_item_metadata` and
  `zotero_search_items`.

**Reverse lookup works, but only against a local Zotero API.** Searching a
citation key resolves to its item in *both* query modes on the local API —
Zotero's quicksearch indexes `citationKey`, so `\cite{kimiK25}` → item needs no
extra tooling. The Zotero Web API does **not** index it: `q=kimiK25` returns
zero results in either `qmode` even though the same request returns
`citationKey: "kimiK25"` in the item payload, so this is an indexing difference
rather than sync lag. Documented on the `qmode` parameter, since a silent
zero-result search is the worst failure mode for the use case #18 asked about.

## Search behavior documentation

The second commit rewrites the `zotero_search_items` description and adds
per-parameter `Field` descriptions — the generated schema previously exposed
bare types with no guidance on choosing a `qmode`. Behavior was established
empirically against both APIs, because the
[docs](https://www.zotero.org/support/dev/web_api/v3/basics#searching) are thin
and in one respect outdated:

| Behavior | Local API | Web API |
| --- | --- | --- |
| `titleCreatorYear` → title, creators, year | ✅ | ✅ |
| `titleCreatorYear` → `citationKey` | ✅ | ❌ |
| `titleCreatorYear` → abstract / `Extra` | ❌ | ❌ |
| `everything` → abstract, `Extra`, notes, attachment full text | ✅ | ✅ |
| Prefix matching (`cybor` → "Cyborg") | ✅ | ✅ |
| Multi-word = all words, any position (**not** phrase-only) | ✅ | ✅ |

Two findings drove most of the wording. `titleCreatorYear` not matching
abstracts is the most likely way to use the tool wrong — a term that appears
only in an abstract returns nothing. And `everything` returns matching
attachments and notes as top-level results that usually *dominate*:
representative queries came back 5/6, 6/8 and 7/8 child items, which at the
default `limit` of 10 can crowd out parent items entirely.

## Known follow-ups

`format_item()` renders every creator, so a paper with hundreds of authors
(e.g. `Kimi K2`) produces a very long `Authors:` line. `search_items()` already
truncates at 3 + `et al.`. This is pre-existing behavior rather than a
regression, but making the metadata view exhaustive makes it more visible —
worth deciding separately whether the full view should cap creators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


