### PR TITLE
feat: resolve child-item search hits back to the work they belong to

### DIFF
--- a/src/zotero_mcp/__init__.py
+++ b/src/zotero_mcp/__init__.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, NamedTuple
 
 from mcp.server import MCPServer
 from pydantic import Field
@@ -498,9 +498,22 @@ def describe_child_match(child: dict[str, Any]) -> str:
     return f"{item_type} `{key}`"
 
 
+class WorkMatch(NamedTuple):
+    """A work in the search results, with where its matches came from.
+
+    `direct` and `children` are both recorded because a work can match either
+    way or both, and collapsing them would make a work that only turned up
+    through its PDF indistinguishable from one that also matched on its title.
+    """
+
+    item: dict[str, Any]
+    children: list[dict[str, Any]]
+    direct: bool
+
+
 def group_by_work(
     items: list[dict[str, Any]], resolved: dict[str, Any]
-) -> list[tuple[dict[str, Any], list[dict[str, Any]]]]:
+) -> list[WorkMatch]:
     """Group search results by the work they belong to, in first-match order.
 
     A work matched both directly and through its attachments appears once. A
@@ -523,12 +536,17 @@ def group_by_work(
 
         key = work["key"]
         if key not in works:
-            works[key] = {"item": work, "children": []}
+            works[key] = {"item": work, "children": [], "direct": False}
             order.append(key)
-        if work is not item:
+        if work is item:
+            works[key]["direct"] = True
+        else:
             works[key]["children"].append(item)
 
-    return [(works[key]["item"], works[key]["children"]) for key in order]
+    return [
+        WorkMatch(works[key]["item"], works[key]["children"], works[key]["direct"])
+        for key in order
+    ]
 
 
 # Search behaviour below was verified against both a local Zotero API and
@@ -644,7 +662,7 @@ def search_items(
     # collapsing nothing (six child hits, no two sharing a parent), and gating
     # the resolution clause on collapsing would leave that search describing
     # itself exactly like a title-only one.
-    resolved = sum(1 for _, children in groups if children)
+    resolved = sum(1 for group in groups if group.children)
 
     found = f"Found {len(groups)} items"
     if len(groups) != matched:
@@ -684,16 +702,20 @@ def search_items(
 
     # Format results
     formatted_results = []
-    for i, (item, matched_children) in enumerate(groups):
+    for i, group in enumerate(groups):
+        item = group.item
         data = item["data"]
         item_key = item.get("key", "")
         item_type = data.get("itemType", "unknown")
-        matched_in = (
-            "**Matched in**: "
-            + ", ".join(describe_child_match(child) for child in matched_children)
-            if matched_children
-            else None
-        )
+
+        # Only worth a line when a child matched, since that provenance is not
+        # otherwise visible. "this item" is listed alongside so a work that
+        # matched both ways stays distinguishable from one found only in a PDF.
+        matched_in = None
+        if group.children:
+            sources = ["this item"] if group.direct else []
+            sources += [describe_child_match(child) for child in group.children]
+            matched_in = "**Matched in**: " + ", ".join(sources)
 
         # Special handling for notes
         if item_type == "note":

--- a/src/zotero_mcp/__init__.py
+++ b/src/zotero_mcp/__init__.py
@@ -662,15 +662,20 @@ def search_items(
     # collapsing nothing (six child hits, no two sharing a parent), and gating
     # the resolution clause on collapsing would leave that search describing
     # itself exactly like a title-only one.
-    resolved = sum(1 for group in groups if group.children)
+    # Counted over matches, not works, and phrased to attach to the match count
+    # it follows. Counting works here would let "all" describe a result set
+    # whose matches were only partly child hits: four works each with one PDF
+    # hit, two of which also matched on their titles, is 8 of 10 matches rather
+    # than all of them.
+    child_matches = sum(1 for item in results if item["data"].get("parentItem"))
 
     found = f"Found {len(groups)} items"
-    if len(groups) != matched:
+    if child_matches:
+        found += f" across {matched} matches, "
+        found += "all" if child_matches == matched else str(child_matches)
+        found += " of which were inside attachments or notes"
+    elif len(groups) != matched:
         found += f" across {matched} matches"
-    if resolved == len(groups):
-        found += ", all matched inside attachments or notes"
-    elif resolved:
-        found += f", {resolved} matched inside attachments or notes"
     found += "."
 
     # Say explicitly when there is more to fetch. Item count alone cannot convey
@@ -678,7 +683,7 @@ def search_items(
     # requested, so a short list is not evidence the result set was exhausted.
     if total_matches is not None and total_matches > matched:
         found += (
-            f" These are the first {matched} of {total_matches} total matches"
+            f" These are the first {matched} of {total_matches} matches"
             " -- raise `limit` to see the rest."
         )
     elif total_matches is None and limit is not None and matched >= limit:

--- a/src/zotero_mcp/__init__.py
+++ b/src/zotero_mcp/__init__.py
@@ -464,6 +464,21 @@ def resolve_parents(zot: Any, items: list[dict[str, Any]]) -> dict[str, Any]:
     return resolved
 
 
+def get_total_results(zot: Any) -> int | None:
+    """Get the total match count Zotero reported for the most recent request.
+
+    Comparing this against the results in hand is what distinguishes a complete
+    result set from one that `limit` truncated. Only reflects the request most
+    recently made through this client, so read it before issuing another.
+    """
+    try:
+        return int(zot.request.headers["Total-Results"])
+    except (AttributeError, KeyError, TypeError, ValueError):
+        # Header absent or unparseable; callers fall back to comparing against
+        # the requested limit.
+        return None
+
+
 def describe_child_match(child: dict[str, Any]) -> str:
     """Describe where a child item's match occurred, for a search result line"""
     data = child["data"]
@@ -571,9 +586,11 @@ def search_items(
         int | None,
         Field(
             description=(
-                "Maximum number of results. Worth raising when qmode is 'everything', "
-                "where several attachments or notes belonging to one work can each "
-                "match separately."
+                "Maximum number of matches to retrieve. This caps matches rather "
+                "than items, and several attachments or notes belonging to one work "
+                "can each match separately, so a search can return fewer items than "
+                "this number while still having more to fetch. The result header "
+                "reports the total whenever that happens."
             )
         ),
     ] = 10,
@@ -593,16 +610,32 @@ def search_items(
     if not results:
         return "No items found matching your query."
 
+    # Read before resolving parents, which issues further requests and so
+    # replaces the response this reflects.
+    total_matches = get_total_results(zot)
+    matched = len(results)
+
     groups = group_by_work(results, resolve_parents(zot, results))
 
     # Header with search info
-    if len(groups) == len(results):
+    if len(groups) == matched:
         found = f"Found {len(groups)} items."
     else:
         found = (
-            f"Found {len(groups)} items across {len(results)} matches, "
+            f"Found {len(groups)} items across {matched} matches, "
             "some of which matched inside attachments or notes."
         )
+
+    # Say explicitly when there is more to fetch. Item count alone cannot convey
+    # this: grouping means a full page of matches can yield fewer items than
+    # requested, so a short list is not evidence the result set was exhausted.
+    if total_matches is not None and total_matches > matched:
+        found += (
+            f" These are the first {matched} of {total_matches} total matches"
+            " -- raise `limit` to see the rest."
+        )
+    elif total_matches is None and limit is not None and matched >= limit:
+        found += f" This reached the limit of {limit} matches, so there may be more."
     header = [
         f"# Search Results for: '{query}'",
         found + (f" Using tag filter: {tag}" if tag else ""),

--- a/src/zotero_mcp/__init__.py
+++ b/src/zotero_mcp/__init__.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from typing import Annotated, Any, Literal
 
@@ -5,6 +6,8 @@ from mcp.server import MCPServer
 from pydantic import Field
 
 from zotero_mcp.client import get_attachment_details, get_zotero_client
+
+logger = logging.getLogger(__name__)
 
 # Create an MCP server
 mcp = MCPServer("Zotero")
@@ -407,6 +410,106 @@ def get_item_fulltext(item_key: str) -> str:
         return f"Error retrieving item full text: {e!s}"
 
 
+# Child items are returned as search results in their own right, and under
+# qmode="everything" they are usually the majority: a term found in a PDF
+# surfaces the attachment, not the work it belongs to. Those hits are the whole
+# point of full-text search -- on a real library a single query returned 24
+# child items covering 22 works, 21 of which matched *only* through their
+# attachments -- so they are resolved back to their work rather than dropped.
+PARENT_FETCH_BATCH = 50
+
+# Annotations hang off an attachment rather than off the work directly, so
+# walking up from an annotation takes two hops.
+PARENT_RESOLUTION_DEPTH = 2
+
+
+def fetch_items_by_key(zot: Any, keys: set[str]) -> dict[str, Any]:
+    """Fetch items by key, batched, as a key -> item mapping"""
+    fetched: dict[str, Any] = {}
+    ordered = sorted(keys)
+    for start in range(0, len(ordered), PARENT_FETCH_BATCH):
+        batch = ordered[start : start + PARENT_FETCH_BATCH]
+        try:
+            zot.add_parameters(itemKey=",".join(batch), limit=100)
+            results: Any = zot.items()
+        except Exception:
+            # Best-effort: an unresolved parent degrades to rendering the child
+            # item on its own, which is what this server did previously.
+            logger.debug("Failed to resolve items %s", batch, exc_info=True)
+            continue
+        for item in results:
+            fetched[item["key"]] = item
+    return fetched
+
+
+def resolve_parents(zot: Any, items: list[dict[str, Any]]) -> dict[str, Any]:
+    """Fetch the ancestors of any child items among the search results"""
+    resolved: dict[str, Any] = {}
+    pending = {
+        parent
+        for item in items
+        if (parent := item["data"].get("parentItem"))
+        and parent not in {i["key"] for i in items}
+    }
+    for _ in range(PARENT_RESOLUTION_DEPTH):
+        if not pending:
+            break
+        fetched = fetch_items_by_key(zot, pending)
+        resolved.update(fetched)
+        pending = {
+            parent
+            for item in fetched.values()
+            if (parent := item["data"].get("parentItem")) and parent not in resolved
+        }
+    return resolved
+
+
+def describe_child_match(child: dict[str, Any]) -> str:
+    """Describe where a child item's match occurred, for a search result line"""
+    data = child["data"]
+    item_type = data.get("itemType", "item")
+    key = child["key"]
+    if item_type == "attachment":
+        title = data.get("title") or data.get("filename")
+        return f"attachment full text{f' ({title})' if title else ''} `{key}`"
+    if item_type == "annotation":
+        return f"{data.get('annotationType', 'highlight')} annotation `{key}`"
+    return f"{item_type} `{key}`"
+
+
+def group_by_work(
+    items: list[dict[str, Any]], resolved: dict[str, Any]
+) -> list[tuple[dict[str, Any], list[dict[str, Any]]]]:
+    """Group search results by the work they belong to, in first-match order.
+
+    A work matched both directly and through its attachments appears once. A
+    child whose parent could not be resolved stays on its own, so nothing that
+    matched is ever dropped from the results.
+    """
+    works: dict[str, dict[str, Any]] = {}
+    order: list[str] = []
+    lookup = {item["key"]: item for item in items} | resolved
+
+    for item in items:
+        work = item
+        # Walk up to the top-level work, guarding against a cycle or a missing
+        # ancestor by bounding the climb.
+        for _ in range(PARENT_RESOLUTION_DEPTH):
+            parent_key = work["data"].get("parentItem")
+            if not parent_key or parent_key not in lookup:
+                break
+            work = lookup[parent_key]
+
+        key = work["key"]
+        if key not in works:
+            works[key] = {"item": work, "children": []}
+            order.append(key)
+        if work is not item:
+            works[key]["children"].append(item)
+
+    return [(works[key]["item"], works[key]["children"]) for key in order]
+
+
 # Search behaviour below was verified against both a local Zotero API and
 # api.zotero.org rather than taken from the docs, which are thin and in one
 # respect outdated: https://www.zotero.org/support/dev/web_api/v3/basics#searching
@@ -490,19 +593,34 @@ def search_items(
     if not results:
         return "No items found matching your query."
 
+    groups = group_by_work(results, resolve_parents(zot, results))
+
     # Header with search info
+    if len(groups) == len(results):
+        found = f"Found {len(groups)} items."
+    else:
+        found = (
+            f"Found {len(groups)} items across {len(results)} matches, "
+            "some of which matched inside attachments or notes."
+        )
     header = [
         f"# Search Results for: '{query}'",
-        f"Found {len(results)} items." + (f" Using tag filter: {tag}" if tag else ""),
+        found + (f" Using tag filter: {tag}" if tag else ""),
         "Use item keys with zotero_item_metadata or zotero_item_fulltext for more details.\n",
     ]
 
     # Format results
     formatted_results = []
-    for i, item in enumerate(results):
+    for i, (item, matched_children) in enumerate(groups):
         data = item["data"]
         item_key = item.get("key", "")
         item_type = data.get("itemType", "unknown")
+        matched_in = (
+            "**Matched in**: "
+            + ", ".join(describe_child_match(child) for child in matched_children)
+            if matched_children
+            else None
+        )
 
         # Special handling for notes
         if item_type == "note":
@@ -539,6 +657,8 @@ def search_items(
             # Add parent item reference if available
             if parent_item := data.get("parentItem"):
                 entry.insert(2, f"**Parent Item**: `{parent_item}`")
+            if matched_in:
+                entry.insert(2, matched_in)
 
             # Add tags if present (limited to first 5)
             if tags := data.get("tags"):
@@ -584,6 +704,9 @@ def search_items(
 
         if source := get_source(data):
             entry.append(f"**Source**: {source}")
+
+        if matched_in:
+            entry.append(matched_in)
 
         if abstract:
             entry.append(f"\n{abstract}")

--- a/src/zotero_mcp/__init__.py
+++ b/src/zotero_mcp/__init__.py
@@ -416,6 +416,12 @@ def get_item_fulltext(item_key: str) -> str:
 # point of full-text search -- on a real library a single query returned 24
 # child items covering 22 works, 21 of which matched *only* through their
 # attachments -- so they are resolved back to their work rather than dropped.
+# A hyphen between word characters, which Zotero treats as a word separator and
+# then ORs rather than ANDs: 'oxygen-deprived' returned 175 matches against a
+# library where 'oxygen' matched 164, 'deprived' 16, and 'oxygen deprived' 5 --
+# exactly the union of the two halves.
+HYPHENATED_TERM = re.compile(r"\w-\w")
+
 PARENT_FETCH_BATCH = 50
 
 # Annotations hang off an attachment rather than off the work directly, so
@@ -543,8 +549,12 @@ def group_by_work(
         "- 'everything' additionally searches abstracts, the Extra field, note text, "
         "and the full text of attachments. Use it for topic and full-text search, "
         "where the term would not appear in a title.\n\n"
-        "Words match by prefix and multi-word queries match items containing all of "
-        "the words in any position, so 'cybor insect' matches 'Cyborg Insect'."
+        "Words match by prefix, and space-separated words must all be present "
+        "though not necessarily adjacent, so 'cybor insect' matches 'Cyborg "
+        "Insect'. A hyphen separates words and switches the match to OR: "
+        "'oxygen-deprived' matches anything containing 'oxygen' or 'deprived', "
+        "which is far broader than intended. Write hyphenated terms with a space "
+        "to require both halves."
     ),
 )
 def search_items(
@@ -552,8 +562,11 @@ def search_items(
         str,
         Field(
             description=(
-                "Text to match. Words match by prefix, and an item must contain every "
-                "word in the query, though not necessarily as a contiguous phrase."
+                "Text to match. Words match by prefix, and every space-separated "
+                "word must be present, though not necessarily as a contiguous "
+                "phrase. A hyphen separates words and ORs them instead, so "
+                "'oxygen-deprived' matches items containing either half; write it "
+                "with a space to require both."
             )
         ),
     ],
@@ -608,7 +621,16 @@ def search_items(
     results: Any = zot.items()
 
     if not results:
-        return "No items found matching your query."
+        # The default mode not searching abstracts is the likeliest reason a
+        # query that should have matched didn't, so say so where it is
+        # actionable rather than only in the tool description.
+        if qmode == "everything":
+            return "No items found matching your query."
+        return (
+            "No items found matching your query. This searched titles, creators, "
+            "and years only; retry with qmode='everything' to also search "
+            "abstracts, notes, and the full text of attachments."
+        )
 
     # Read before resolving parents, which issues further requests and so
     # replaces the response this reflects.
@@ -617,14 +639,21 @@ def search_items(
 
     groups = group_by_work(results, resolve_parents(zot, results))
 
-    # Header with search info
-    if len(groups) == matched:
-        found = f"Found {len(groups)} items."
-    else:
-        found = (
-            f"Found {len(groups)} items across {matched} matches, "
-            "some of which matched inside attachments or notes."
-        )
+    # Collapsing and resolution are independent facts and are reported
+    # separately. A search can resolve every result through a PDF while
+    # collapsing nothing (six child hits, no two sharing a parent), and gating
+    # the resolution clause on collapsing would leave that search describing
+    # itself exactly like a title-only one.
+    resolved = sum(1 for _, children in groups if children)
+
+    found = f"Found {len(groups)} items"
+    if len(groups) != matched:
+        found += f" across {matched} matches"
+    if resolved == len(groups):
+        found += ", all matched inside attachments or notes"
+    elif resolved:
+        found += f", {resolved} matched inside attachments or notes"
+    found += "."
 
     # Say explicitly when there is more to fetch. Item count alone cannot convey
     # this: grouping means a full page of matches can yield fewer items than
@@ -639,8 +668,19 @@ def search_items(
     header = [
         f"# Search Results for: '{query}'",
         found + (f" Using tag filter: {tag}" if tag else ""),
-        "Use item keys with zotero_item_metadata or zotero_item_fulltext for more details.\n",
     ]
+    # Zotero splits on the hyphen and ORs the halves, so a hyphenated term
+    # silently matches far more than the caller asked for. Worth saying here
+    # rather than only in the tool description, since the results look
+    # plausible and nothing else signals it.
+    if HYPHENATED_TERM.search(query):
+        header.append(
+            "Note: the hyphen in this query was read as OR, matching either half "
+            "separately. Replace it with a space to require both."
+        )
+    header.append(
+        "Use item keys with zotero_item_metadata or zotero_item_fulltext for more details.\n"
+    )
 
     # Format results
     formatted_results = []

--- a/tests/test_search_grouping.py
+++ b/tests/test_search_grouping.py
@@ -134,6 +134,98 @@ def test_resolution_survives_a_failed_lookup(mock_zotero: Any) -> None:
     assert "Some PDF" in result
 
 
+def test_header_reports_resolution_without_any_collapsing(mock_zotero: Any) -> None:
+    """Every result resolved through a PDF, but no two share a parent"""
+    mock_zotero.items.side_effect = [
+        [child(f"ATT0000{i}", f"PARENT0{i}") for i in range(1, 4)],
+        [work(f"PARENT0{i}") for i in range(1, 4)],
+    ]
+
+    result = search_items("memory persistence", qmode="everything")
+
+    # Nothing collapsed, so the count of works equals the count of matches.
+    assert "across" not in result.split("\n")[2]
+    assert "Found 3 items, all matched inside attachments or notes." in result
+
+
+def test_header_stays_quiet_for_metadata_only_matches(mock_zotero: Any) -> None:
+    """Title and creator matches read the same as they always did"""
+    mock_zotero.items.return_value = [work("PARENT01"), work("PARENT02")]
+
+    result = search_items("test")
+
+    assert "Found 2 items." in result
+    assert "attachments or notes" not in result
+
+
+def test_header_counts_partial_resolution(mock_zotero: Any) -> None:
+    """A mix of metadata and child matches reports how many came from children"""
+    mock_zotero.items.side_effect = [
+        [work("PARENT01"), work("PARENT02"), child("ATT00001", "PARENT03")],
+        [work("PARENT03")],
+    ]
+
+    result = search_items("test", qmode="everything")
+
+    assert "Found 3 items, 1 matched inside attachments or notes." in result
+
+
+def test_header_reports_collapsing_and_resolution_together(mock_zotero: Any) -> None:
+    """Both facts appear when both apply"""
+    mock_zotero.items.side_effect = [
+        [
+            child("ATT00001", "PARENT01"),
+            child("ATT00002", "PARENT01"),
+            work("PARENT02"),
+        ],
+        [work("PARENT01")],
+    ]
+
+    result = search_items("test", qmode="everything")
+
+    assert (
+        "Found 2 items across 3 matches, 1 matched inside attachments or notes."
+        in result
+    )
+
+
+def test_hyphenated_query_is_flagged(mock_zotero: Any) -> None:
+    """Zotero ORs the halves of a hyphenated term, which nothing else signals"""
+    mock_zotero.items.return_value = [work("PARENT01")]
+
+    result = search_items("oxygen-deprived")
+
+    assert "read as OR" in result
+    assert "Replace it with a space" in result
+
+
+def test_unhyphenated_query_is_not_flagged(mock_zotero: Any) -> None:
+    """The note only appears when a hyphen actually joins two words"""
+    mock_zotero.items.return_value = [work("PARENT01")]
+
+    assert "read as OR" not in search_items("oxygen deprived")
+    assert "read as OR" not in search_items("-deprived")
+
+
+def test_empty_results_suggest_everything_mode(mock_zotero: Any) -> None:
+    """The default mode not searching abstracts is worth saying at zero results"""
+    mock_zotero.items.return_value = []
+
+    result = search_items("oxygen-deprived")
+
+    assert "qmode='everything'" in result
+    assert "titles, creators, and years only" in result
+
+
+def test_empty_results_in_everything_mode_suggest_nothing(mock_zotero: Any) -> None:
+    """There is no wider mode to recommend once everything has been tried"""
+    mock_zotero.items.return_value = []
+
+    result = search_items("oxygen-deprived", qmode="everything")
+
+    assert result == "No items found matching your query."
+
+
 def with_total(mock_zotero: Any, total: int) -> None:
     """Give the mocked client a Total-Results header, as Zotero returns"""
     mock_zotero.request = MagicMock()

--- a/tests/test_search_grouping.py
+++ b/tests/test_search_grouping.py
@@ -1,6 +1,7 @@
 """Tests for resolving child-item search hits back to the work they belong to"""
 
 from typing import Any
+from unittest.mock import MagicMock
 
 from zotero_mcp import group_by_work, search_items
 
@@ -131,6 +132,85 @@ def test_resolution_survives_a_failed_lookup(mock_zotero: Any) -> None:
     result = search_items("test", qmode="everything")
 
     assert "Some PDF" in result
+
+
+def with_total(mock_zotero: Any, total: int) -> None:
+    """Give the mocked client a Total-Results header, as Zotero returns"""
+    mock_zotero.request = MagicMock()
+    mock_zotero.request.headers = {"Total-Results": str(total)}
+
+
+def test_truncated_results_report_the_total(mock_zotero: Any) -> None:
+    """A capped result set says so, since that is when the caller should re-query"""
+    mock_zotero.items.return_value = [work("PARENT01"), work("PARENT02")]
+    with_total(mock_zotero, 137)
+
+    result = search_items("test", limit=2)
+
+    assert "first 2 of 137 total matches" in result
+    assert "raise `limit`" in result
+
+
+def test_complete_results_say_nothing_extra(mock_zotero: Any) -> None:
+    """A complete result set is not qualified, so silence means exhausted"""
+    mock_zotero.items.return_value = [work("PARENT01"), work("PARENT02")]
+    with_total(mock_zotero, 2)
+
+    result = search_items("test", limit=10)
+
+    assert "total matches" not in result
+    assert "Found 2 items." in result
+
+
+def test_grouped_and_truncated_reports_both(mock_zotero: Any) -> None:
+    """Grouping and truncation are distinct facts and both get reported"""
+    mock_zotero.items.side_effect = [
+        [
+            child("ATT00001", "PARENT01"),
+            child("ATT00002", "PARENT01"),
+            child("ATT00003", "PARENT02"),
+        ],
+        [work("PARENT01"), work("PARENT02")],
+    ]
+    with_total(mock_zotero, 99)
+
+    result = search_items("test", qmode="everything", limit=3)
+
+    assert "Found 2 items across 3 matches" in result
+    assert "first 3 of 99 total matches" in result
+
+
+def test_fewer_items_than_limit_can_still_be_truncated(mock_zotero: Any) -> None:
+    """The case the item count alone cannot express: 4 items from a full page"""
+    mock_zotero.items.side_effect = [
+        [child(f"ATT0000{i}", "PARENT01") for i in range(1, 11)],
+        [work("PARENT01")],
+    ]
+    with_total(mock_zotero, 1093)
+
+    result = search_items("test", qmode="everything", limit=10)
+
+    assert "Found 1 items across 10 matches" in result
+    assert "first 10 of 1093 total matches" in result
+
+
+def test_falls_back_to_limit_when_header_missing(mock_zotero: Any) -> None:
+    """Without Total-Results, a full page is still flagged as possibly truncated"""
+    mock_zotero.items.return_value = [work("PARENT01"), work("PARENT02")]
+
+    result = search_items("test", limit=2)
+
+    assert "reached the limit of 2 matches" in result
+
+
+def test_no_truncation_note_when_under_limit_without_header(mock_zotero: Any) -> None:
+    """A short page without the header is treated as complete"""
+    mock_zotero.items.return_value = [work("PARENT01")]
+
+    result = search_items("test", limit=10)
+
+    assert "reached the limit" not in result
+    assert "total matches" not in result
 
 
 def test_standalone_note_is_unaffected(mock_zotero: Any) -> None:

--- a/tests/test_search_grouping.py
+++ b/tests/test_search_grouping.py
@@ -162,9 +162,13 @@ def test_header_reports_resolution_without_any_collapsing(mock_zotero: Any) -> N
 
     result = search_items("memory persistence", qmode="everything")
 
-    # Nothing collapsed, so the count of works equals the count of matches.
-    assert "across" not in result.split("\n")[2]
-    assert "Found 3 items, all matched inside attachments or notes." in result
+    # Nothing collapsed -- works equals matches -- yet the resolution is still
+    # reported, which is the whole point. The match count stays as the
+    # denominator for "all of which".
+    assert (
+        "Found 3 items across 3 matches, all of which were inside attachments or notes."
+        in result
+    )
 
 
 def test_header_stays_quiet_for_metadata_only_matches(mock_zotero: Any) -> None:
@@ -186,7 +190,10 @@ def test_header_counts_partial_resolution(mock_zotero: Any) -> None:
 
     result = search_items("test", qmode="everything")
 
-    assert "Found 3 items, 1 matched inside attachments or notes." in result
+    assert (
+        "Found 3 items across 3 matches, 1 of which were inside attachments or notes."
+        in result
+    )
 
 
 def test_header_reports_collapsing_and_resolution_together(mock_zotero: Any) -> None:
@@ -203,7 +210,7 @@ def test_header_reports_collapsing_and_resolution_together(mock_zotero: Any) -> 
     result = search_items("test", qmode="everything")
 
     assert (
-        "Found 2 items across 3 matches, 1 matched inside attachments or notes."
+        "Found 2 items across 3 matches, 2 of which were inside attachments or notes."
         in result
     )
 
@@ -258,7 +265,7 @@ def test_truncated_results_report_the_total(mock_zotero: Any) -> None:
 
     result = search_items("test", limit=2)
 
-    assert "first 2 of 137 total matches" in result
+    assert "first 2 of 137 matches" in result
     assert "raise `limit`" in result
 
 
@@ -269,7 +276,7 @@ def test_complete_results_say_nothing_extra(mock_zotero: Any) -> None:
 
     result = search_items("test", limit=10)
 
-    assert "total matches" not in result
+    assert "of 2 matches" not in result
     assert "Found 2 items." in result
 
 
@@ -288,7 +295,7 @@ def test_grouped_and_truncated_reports_both(mock_zotero: Any) -> None:
     result = search_items("test", qmode="everything", limit=3)
 
     assert "Found 2 items across 3 matches" in result
-    assert "first 3 of 99 total matches" in result
+    assert "first 3 of 99 matches" in result
 
 
 def test_fewer_items_than_limit_can_still_be_truncated(mock_zotero: Any) -> None:
@@ -302,7 +309,7 @@ def test_fewer_items_than_limit_can_still_be_truncated(mock_zotero: Any) -> None
     result = search_items("test", qmode="everything", limit=10)
 
     assert "Found 1 items across 10 matches" in result
-    assert "first 10 of 1093 total matches" in result
+    assert "first 10 of 1093 matches" in result
 
 
 def test_falls_back_to_limit_when_header_missing(mock_zotero: Any) -> None:
@@ -321,7 +328,7 @@ def test_no_truncation_note_when_under_limit_without_header(mock_zotero: Any) ->
     result = search_items("test", limit=10)
 
     assert "reached the limit" not in result
-    assert "total matches" not in result
+    assert "of 2 matches" not in result
 
 
 def test_standalone_note_is_unaffected(mock_zotero: Any) -> None:

--- a/tests/test_search_grouping.py
+++ b/tests/test_search_grouping.py
@@ -1,0 +1,147 @@
+"""Tests for resolving child-item search hits back to the work they belong to"""
+
+from typing import Any
+
+from zotero_mcp import group_by_work, search_items
+
+
+def child(key: str, parent: str, item_type: str = "attachment", **data: Any) -> dict:
+    return {
+        "key": key,
+        "data": {"key": key, "itemType": item_type, "parentItem": parent, **data},
+    }
+
+
+def work(key: str, title: str = "A Paper") -> dict:
+    return {
+        "key": key,
+        "data": {"key": key, "itemType": "journalArticle", "title": title},
+    }
+
+
+def test_child_hit_resolves_to_its_work(mock_zotero: Any) -> None:
+    """A PDF full-text hit is reported as the work, not as an anonymous attachment"""
+    parent = work("PARENT01", "Underwater Cyborg Insects")
+    mock_zotero.items.side_effect = [[child("ATT00001", "PARENT01")], [parent]]
+
+    result = search_items("oxygen-deprived", qmode="everything")
+
+    assert "Underwater Cyborg Insects" in result
+    assert "**Key**: `PARENT01`" in result
+    assert "**Matched in**: attachment full text `ATT00001`" in result
+
+
+def test_work_and_its_child_are_not_duplicated(mock_zotero: Any) -> None:
+    """A work matching directly and through its attachment appears once"""
+    parent = work("PARENT01")
+    mock_zotero.items.return_value = [parent, child("ATT00001", "PARENT01")]
+
+    result = search_items("test", qmode="everything")
+
+    assert result.count("**Key**: `PARENT01`") == 1
+    assert "Found 1 items across 2 matches" in result
+    assert "**Matched in**: attachment full text `ATT00001`" in result
+
+
+def test_multiple_children_listed_together(mock_zotero: Any) -> None:
+    """Every child match for a work is reported on one line"""
+    parent = work("PARENT01")
+    mock_zotero.items.side_effect = [
+        [
+            child("ATT00001", "PARENT01", title="Preprint PDF"),
+            child("NOTE0001", "PARENT01", item_type="note", note="<p>a note</p>"),
+        ],
+        [parent],
+    ]
+
+    result = search_items("test", qmode="everything")
+
+    assert "attachment full text (Preprint PDF) `ATT00001`" in result
+    assert "note `NOTE0001`" in result
+
+
+def test_annotation_resolves_two_levels(mock_zotero: Any) -> None:
+    """Annotations hang off an attachment, so resolution takes two hops"""
+    annotation = child(
+        "ANNO0001", "ATT00001", item_type="annotation", annotationType="highlight"
+    )
+    attachment = child("ATT00001", "PARENT01")
+    parent = work("PARENT01", "Coreference Models")
+    mock_zotero.items.side_effect = [[annotation], [attachment], [parent]]
+
+    result = search_items("pairwise model", qmode="everything")
+
+    assert "Coreference Models" in result
+    assert "**Matched in**: highlight annotation `ANNO0001`" in result
+
+
+def test_unresolvable_parent_keeps_the_child(mock_zotero: Any) -> None:
+    """Nothing that matched is dropped when a parent cannot be fetched"""
+    orphan = child("ATT00001", "MISSING1", title="Orphan PDF")
+    mock_zotero.items.side_effect = [[orphan], []]
+
+    result = search_items("test", qmode="everything")
+
+    assert "Orphan PDF" in result
+    assert "**Key**: `ATT00001`" in result
+
+
+def test_no_extra_request_without_child_hits(
+    mock_zotero: Any, sample_item: dict[str, Any]
+) -> None:
+    """Searches that match no child items make a single API call"""
+    mock_zotero.items.return_value = [sample_item]
+
+    search_items("test")
+
+    assert mock_zotero.items.call_count == 1
+    mock_zotero.add_parameters.assert_called_once()
+
+
+def test_parent_already_in_results_is_not_refetched(mock_zotero: Any) -> None:
+    """A parent present in the results does not trigger a lookup"""
+    mock_zotero.items.return_value = [work("PARENT01"), child("ATT00001", "PARENT01")]
+
+    search_items("test", qmode="everything")
+
+    assert mock_zotero.items.call_count == 1
+
+
+def test_group_by_work_preserves_first_match_order() -> None:
+    """Grouping keeps the order Zotero returned results in"""
+    items = [
+        child("ATT00002", "PARENT02"),
+        work("PARENT01"),
+        child("ATT00001", "PARENT01"),
+    ]
+    resolved = {"PARENT02": work("PARENT02")}
+
+    grouped = group_by_work(items, resolved)
+
+    assert [item["key"] for item, _ in grouped] == ["PARENT02", "PARENT01"]
+
+
+def test_resolution_survives_a_failed_lookup(mock_zotero: Any) -> None:
+    """An API error while resolving degrades to rendering the child item"""
+    mock_zotero.items.side_effect = [
+        [child("ATT00001", "PARENT01", title="Some PDF")],
+        RuntimeError("api exploded"),
+    ]
+
+    result = search_items("test", qmode="everything")
+
+    assert "Some PDF" in result
+
+
+def test_standalone_note_is_unaffected(mock_zotero: Any) -> None:
+    """Notes without a parent keep their own rendering"""
+    note = {
+        "key": "NOTE0001",
+        "data": {"key": "NOTE0001", "itemType": "note", "note": "<p>Standalone</p>"},
+    }
+    mock_zotero.items.return_value = [note]
+
+    result = search_items("test")
+
+    assert "📝" in result
+    assert "Standalone" in result

--- a/tests/test_search_grouping.py
+++ b/tests/test_search_grouping.py
@@ -41,7 +41,26 @@ def test_work_and_its_child_are_not_duplicated(mock_zotero: Any) -> None:
 
     assert result.count("**Key**: `PARENT01`") == 1
     assert "Found 1 items across 2 matches" in result
-    assert "**Matched in**: attachment full text `ATT00001`" in result
+    # The work matched on its own fields too, so the provenance says so rather
+    # than crediting the attachment alone.
+    assert "**Matched in**: this item, attachment full text `ATT00001`" in result
+
+
+def test_direct_and_child_matches_are_distinguishable(mock_zotero: Any) -> None:
+    """A work found only via its PDF must not look like one that also matched"""
+    mock_zotero.items.side_effect = [
+        [
+            child("ATT_A", "WORK_A"),
+            work("WORK_B", "Matched Both Ways"),
+            child("ATT_B", "WORK_B"),
+        ],
+        [work("WORK_A", "Only Its PDF Matched")],
+    ]
+
+    result = search_items("test", qmode="everything")
+
+    assert "**Matched in**: attachment full text `ATT_A`" in result
+    assert "**Matched in**: this item, attachment full text `ATT_B`" in result
 
 
 def test_multiple_children_listed_together(mock_zotero: Any) -> None:
@@ -119,7 +138,7 @@ def test_group_by_work_preserves_first_match_order() -> None:
 
     grouped = group_by_work(items, resolved)
 
-    assert [item["key"] for item, _ in grouped] == ["PARENT02", "PARENT01"]
+    assert [group.item["key"] for group in grouped] == ["PARENT02", "PARENT01"]
 
 
 def test_resolution_survives_a_failed_lookup(mock_zotero: Any) -> None:


### PR DESCRIPTION
Follows #24, now merged; targets `main`.

## Why

#24 described `qmode=everything`'s attachment hits as noise to filter out with
`itemType=-attachment`. That was backwards. For `q=memory persistence` on a real
library: 25 matches, 20 of them child items, pointing to 20 distinct works —
**all 20 reachable only through their attachment**. Filtering would have
discarded every one.

The attachment hit *is* the signal: it's the only pointer to a work whose
relevance lives in the PDF body, which is the whole reason to use `everything`.
The defect was rendering, which turned those hits into anonymous stubs:

```
## 1. Full Text PDF          ## 3. PDF                ## 4. PDF
**Type**: attachment         **Type**: attachment     **Type**: attachment
**Authors**: No authors      **Authors**: No authors
```

`parentItem` was in the payload all along — only the note branch rendered it.

## What changed

Child hits resolve to their work, which is rendered normally with a
`**Matched in**` line naming where the match occurred. Each work appears once,
even if it matched both directly and through several children.

Resolution never hides the child: its type, filename, and key are all named, so
the exact attachment stays addressable with `zotero_item_fulltext`. Whether the
work *itself* also matched is recorded too, so the two cases stay distinct —
without this, a work found only in a PDF looked identical to one that also
matched on its own fields:

```
**Matched in**: attachment full text (Full Text PDF) `ATT_A`
**Matched in**: this item, attachment full text (Full Text PDF) `ATT_B`
```

The line is omitted entirely when nothing matched through a child, so ordinary
metadata hits are unchanged.

The header reports three independent facts, and stays silent about each when it
doesn't apply:

```
Found 4 items.
Found 6 items, all matched inside attachments or notes. These are the first 6
  of 33 total matches -- raise `limit` to see the rest.
Found 4 items across 10 matches, 2 matched inside attachments or notes. These
  are the first 10 of 193 total matches -- raise `limit` to see the rest.
```

- **Collapsing** (`across N matches`) and **resolution** (`N matched inside…`)
  are separate conditions. Gating the second on the first — as an earlier
  revision did — made a search where everything resolved but nothing collapsed
  read exactly like a title-only search. The resolution count equals the number
  of `Matched in` lines in the body, so summary and entries can't disagree.
- **Truncation** comes from Zotero's `Total-Results` header (present on both
  the local API and `api.zotero.org`), not from inferring `matches == limit`.
  That reports *how much* more exists, and catches the case where `limit`
  exceeds one page. Silence now means the set is exhausted. `Total-Results`
  reflects only the last request, so it's read before parent resolution issues
  its own; if absent, the code falls back to the `matches == limit` heuristic.

`limit` still caps raw matches rather than works — paging over works would mean
over-fetching by an unknown factor — but the header no longer leaves that
ambiguous.

Implementation notes worth knowing up front:

- **One extra request**, batched as `itemKey=A,B,C`, skipped when no child items
  matched. Verified pyzotero's `add_parameters` *replaces* rather than merges,
  so the second call doesn't leak `q`.
- **Two resolution rounds**, since annotations hang off an *attachment*:
  `annotation → attachment → work`.
- **Nothing that matched is ever dropped.** An unresolvable or failed lookup
  leaves the child rendered as before.

## Hyphens are OR, not part of a word

Found while validating the above, when a nonsense query returned 1284 matches.
`q` was being sent correctly — this is Zotero behavior:

| query | matches |
| --- | --- |
| `oxygen` | 164 |
| `deprived` | 16 |
| `oxygen deprived` (AND) | 5 |
| `oxygen-deprived` | **175** — exactly `164 + 16 − 5`, the union |

It fails silently, since results look plausible and relevant near the top. Now
documented on the tool and `query` descriptions, and flagged in the result
header at runtime.

This **corrects figures originally quoted in this PR**, which were measured on
`oxygen-deprived` — effectively `oxygen OR deprived`. The numbers above are
re-measured on a space-separated query. The conclusion is unchanged and in fact
stronger, but the originals weren't measuring what they claimed.

## Validation

58 tests pass; `ruff check` and `ruff format --check` clean. New tests cover
resolution, dedupe, two-level annotations, order preservation, unresolvable
parents, API failure mid-resolution, the no-extra-request path, each header
combination, truncation reporting, and the hyphen and zero-result notices.

Verified live against a local Zotero library for single-child, multi-child
(`kimiK2` → 8 matches collapse to 2 works), and two-level annotation cases.

Also added, since the guidance belongs where it's actionable: an empty result
set under the default `qmode` now says only titles, creators, and years were
searched and suggests `qmode='everything'`. Omitted under `everything`, where
there's no wider mode to recommend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

